### PR TITLE
[BUG] Desactived depreciation test & add test for website builder

### DIFF
--- a/tests/runners/test_runner.py
+++ b/tests/runners/test_runner.py
@@ -39,7 +39,7 @@ class TestPythonRunner(unittest.TestCase):
         qiskit_version, result = runner.workload()
 
         # Uncomment when qiskit-terra gonna be commonly unused.
-        #self.assertFalse(all(r.has_qiskit_deprecation_logs for r in result))
+        # self.assertFalse(all(r.has_qiskit_deprecation_logs for r in result))
         self.assertTrue(all(r.ok for r in result))
         self.assertTrue(qiskit_version)
 

--- a/tests/runners/test_runner.py
+++ b/tests/runners/test_runner.py
@@ -38,7 +38,8 @@ class TestPythonRunner(unittest.TestCase):
         runner.cloned_repo_directory = self.simple_project_dir
         qiskit_version, result = runner.workload()
 
-        self.assertTrue(all(r.has_qiskit_deprecation_logs for r in result))
+        # Uncomment when qiskit-terra gonna be commonly unused.
+        #self.assertFalse(all(r.has_qiskit_deprecation_logs for r in result))
         self.assertTrue(all(r.ok for r in result))
         self.assertTrue(qiskit_version)
 

--- a/tests/runners/test_runner.py
+++ b/tests/runners/test_runner.py
@@ -38,7 +38,7 @@ class TestPythonRunner(unittest.TestCase):
         runner.cloned_repo_directory = self.simple_project_dir
         qiskit_version, result = runner.workload()
 
-        self.assertFalse(all(r.has_qiskit_deprecation_logs for r in result))
+        self.assertTrue(all(r.has_qiskit_deprecation_logs for r in result))
         self.assertTrue(all(r.ok for r in result))
         self.assertTrue(qiskit_version)
 

--- a/tests/runners/test_runner.py
+++ b/tests/runners/test_runner.py
@@ -38,7 +38,7 @@ class TestPythonRunner(unittest.TestCase):
         runner.cloned_repo_directory = self.simple_project_dir
         qiskit_version, result = runner.workload()
 
-        # Uncomment when qiskit-terra gonna be commonly unused.
+        # Uncomment when qiskit-terra is completely unused.
         # self.assertFalse(all(r.has_qiskit_deprecation_logs for r in result))
         self.assertTrue(all(r.ok for r in result))
         self.assertTrue(qiskit_version)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -94,6 +94,11 @@ class TestManager(TestCase):
         if not os.path.exists(self.path):
             os.makedirs(self.path)
 
+    def test_build_website(self):
+        """Test the website builder function."""
+        manager = Manager(root_path=f"{os.path.abspath(os.getcwd())}/../")
+        self.assertIsInstance(manager.build_website(), str)
+
     def test_parser_issue(self):
         """Tests issue parsing function.
         Function: Manager


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The test depreciation test can't be used right now until the new version of qiskit isn't largely used. It come from we still used the old way to check the qiskit version of projects in order to not get the terra version. It will be able to revert this change when qiskit terra gonna totally disappeared.

Cause :
https://github.com/Qiskit/ecosystem/blob/0212a863ffdc1ece3964285ac295db6565500332/ecosystem/templates/configured_tox.ini#L32
As we want to keep the qiskit version and not the terra version we have to keep it this way for now.


### Details and comments
- [x] Update test `test_tests_runner_on_simple_repo`
- [x] Add test `test_website_builder`

---
Closes #572 
