### PR TITLE
Edit descriptions for transpiler plugin projects

### DIFF
--- a/ecosystem/resources/members/dsm-swap.toml
+++ b/ecosystem/resources/members/dsm-swap.toml
@@ -1,6 +1,6 @@
 name = "dsm-swap"
 url = "https://github.com/qiskit-community/dsm-swap"
-description = "A doubly stochastic matrices-based approach to optimal qubit routing"
+description = "A doubly stochastic matrices-based approach to optimal qubit routing."
 licence = "Apache License 2.0"
 contact_info = "_No response_"
 alternatives = "_No response_"

--- a/ecosystem/resources/members/qiskit-bip-mapper.toml
+++ b/ecosystem/resources/members/qiskit-bip-mapper.toml
@@ -1,6 +1,6 @@
 name = "qiskit-bip-mapper"
 url = "https://github.com/qiskit-community/qiskit-bip-mapper"
-description = "The repository contains a standalone routing stage plugin to use the BIPMapping [routing](https://qiskit.org/documentation/apidoc/transpiler.html#routing-stage) pass. The BIP mapping pass solves the routing and [layout](https://qiskit.org/documentation/apidoc/transpiler.html#layout-stage) problems as a binary integer programming (BIP) problem. The algorithm used in this pass is described in: G. Nannicini et al. \"Optimal qubit assignment and routing via integer programming.\" [arXiv:2106.06446](https://arxiv.org/abs/2106.06446)"
+description = "This plugin solves the routing and layout problems as a binary integer programming (BIP) problem. This is an implementation of G. Nannicini et al. \"Optimal qubit assignment and routing via integer programming.\" (arXiv:2106.06446)."
 licence = "Apache License 2.0"
 contact_info = "itoko@jp.ibm.com"
 alternatives = "_No response_"


### PR DESCRIPTION
### Summary

This PR edits a description to be more succinct, and remove markdown.
The reason for editing these first is they'll be higher-focus when we add a separate "transpiler plugins" section.
