### PR TITLE
Allow specifying input / output directories when building website

### DIFF
--- a/ecosystem/__init__.py
+++ b/ecosystem/__init__.py
@@ -5,6 +5,7 @@ from ecosystem.cli import CliMembers, CliCI, build_website
 
 
 def main():
+    # pylint: disable=missing-function-docstring
     fire.Fire(
         {
             "members": CliMembers,

--- a/ecosystem/__init__.py
+++ b/ecosystem/__init__.py
@@ -3,6 +3,7 @@ import fire
 
 from ecosystem.cli import CliMembers, CliCI, build_website
 
+
 def main():
     fire.Fire(
         {

--- a/ecosystem/__init__.py
+++ b/ecosystem/__init__.py
@@ -1,1 +1,13 @@
 """Ecosystem main module."""
+import fire
+
+from ecosystem.cli import CliMembers, CliCI, build_website
+
+def main():
+    fire.Fire(
+        {
+            "members": CliMembers,
+            "build": build_website,
+            "ci": CliCI,
+        }
+    )

--- a/ecosystem/cli/__init__.py
+++ b/ecosystem/cli/__init__.py
@@ -1,4 +1,4 @@
 """CLI."""
 from .members import CliMembers
-from .website import CliWebsite
+from .website import build_website
 from .ci import CliCI

--- a/ecosystem/cli/website.py
+++ b/ecosystem/cli/website.py
@@ -9,132 +9,116 @@ from jinja2 import Environment, FileSystemLoader
 
 from ecosystem.daos import DAO
 
-
-class CliWebsite:
-    """CliMembers class.
-    Entrypoint for all CLI website commands.
-
-    Each public method of this class is CLI command
-    and arguments for method are options/flags for this command.
-
-    Ex: `python manager.py website build_website`
+def build_website(resources: str, output: str):
     """
+    Generates the ecosystem web page from data in `resources` dir, writing to `output` dir.
+    """
+    resources_dir = Path(resources)
+    html = _build_html(*_load_from_file(resources_dir))
+    with open(Path(output, "index.html"), "w") as f:
+        f.write(html)
 
-    def __init__(self, root_path: Optional[str] = None):
-        """CliWebsite class."""
-        pass
+def _load_from_file(resources_dir: Path):
+    """
+    Loads:
+        * Projects list
+        * Website strings
+        * Label descriptions
+        * Jinja templates
+    """
+    # Projects list
+    dao = DAO(path=resources_dir)
+    projects = sorted(
+        dao.get_all(),
+        key=lambda item: (
+            -(item.stars or 0),
+            item.name,
+        ),
+    )
 
-    def _load_from_file(self, resources_dir: Path):
-        """
-        Loads:
-            * Projects list
-            * Website strings
-            * Label descriptions
-            * Jinja templates
-        """
-        # Projects list
-        dao = DAO(path=resources_dir)
-        projects = sorted(
-            dao.get_all(),
-            key=lambda item: (
-                -(item.stars or 0),
-                item.name,
-            ),
-        )
+    # Label descriptions
+    label_descriptions = {
+        item["name"]: item["description"]
+        for item in json.loads(Path(resources_dir, "labels.json").read_text())
+    }
 
-        # Label descriptions
-        label_descriptions = {
-            item["name"]: item["description"]
-            for item in json.loads(Path(resources_dir, "labels.json").read_text())
-        }
+    # Website strings
+    web_data = toml.loads((resources_dir / "website.toml").read_text())
 
-        # Website strings
-        web_data = toml.loads((resources_dir / "website.toml").read_text())
+    # Jinja templates
+    environment = Environment(loader=FileSystemLoader("ecosystem/html_templates/"))
+    templates = {
+        "website": environment.get_template("webpage.html.jinja"),
+        "card": environment.get_template("card.html.jinja"),
+        "tag": environment.get_template("tag.html.jinja"),
+        "link": environment.get_template("link.html.jinja"),
+    }
+    return projects, web_data, label_descriptions, templates
 
-        # Jinja templates
-        environment = Environment(loader=FileSystemLoader("ecosystem/html_templates/"))
-        templates = {
-            "website": environment.get_template("webpage.html.jinja"),
-            "card": environment.get_template("card.html.jinja"),
-            "tag": environment.get_template("tag.html.jinja"),
-            "link": environment.get_template("link.html.jinja"),
-        }
-        return projects, web_data, label_descriptions, templates
+def _build_html(projects, web_data, label_descriptions, templates) -> str:
+    """
+    Take all data needed to build the website and produce a HTML string.
+    """
+    sections = {group["id"]: group for group in web_data["groups"]}
+    for section in sections.values():
+        section.setdefault("html", "")
 
-    def _build_html(self, projects, web_data, label_descriptions, templates) -> str:
-        """
-        Take all data needed to build the website and produce a HTML string.
-        """
-        sections = {group["id"]: group for group in web_data["groups"]}
-        for section in sections.values():
-            section.setdefault("html", "")
-
-        max_chars_description_visible = 400
-        min_chars_description_hidden = 100
-        count_read_more = 1
-        for repo in projects:
-            # Card tags
-            tags = ""
-            for index, label in enumerate(repo.labels):
-                tags += templates["tag"].render(
-                    color="purple",
-                    text=label,
-                    tooltip=label_descriptions[label],
-                    # Sometimes tooltips are clipped by the browser window.
-                    # While not perfect, the following line solves 95% of cases
-                    alignment="bottom" if (index % 3) == 2 else "bottom-left",
-                )
-
-            # Card links
-            links = ""
-            for url, link_text in (
-                (repo.url, "repository"),
-                (repo.website, "website"),
-                (repo.reference_paper, "paper"),
-                (repo.documentation, "documentation"),
-            ):
-                if url:
-                    links += templates["link"].render(url=url, place=link_text)
-
-            # Card description
-            if (
-                len(repo.description) - max_chars_description_visible
-                >= min_chars_description_hidden
-            ):
-                description = [
-                    repo.description[:max_chars_description_visible],
-                    repo.description[max_chars_description_visible:],
-                ]
-                id_read_more = str(count_read_more)
-                count_read_more += 1
-            else:
-                description = [repo.description, ""]
-                id_read_more = "None"
-
-            # Create the card
-            card = templates["card"].render(
-                title=repo.name,
-                tags=tags,
-                description_visible=description[0],
-                description_hidden=description[1],
-                id_read_more=id_read_more,
-                links=links,
+    max_chars_description_visible = 400
+    min_chars_description_hidden = 100
+    count_read_more = 1
+    for repo in projects:
+        # Card tags
+        tags = ""
+        for index, label in enumerate(repo.labels):
+            tags += templates["tag"].render(
+                color="purple",
+                text=label,
+                tooltip=label_descriptions[label],
+                # Sometimes tooltips are clipped by the browser window.
+                # While not perfect, the following line solves 95% of cases
+                alignment="bottom" if (index % 3) == 2 else "bottom-left",
             )
 
-            # Adding the card to a section
-            sections[repo.group]["html"] += card
+        # Card links
+        links = ""
+        for url, link_text in (
+            (repo.url, "repository"),
+            (repo.website, "website"),
+            (repo.reference_paper, "paper"),
+            (repo.documentation, "documentation"),
+        ):
+            if url:
+                links += templates["link"].render(url=url, place=link_text)
 
-        return templates["website"].render(
-            header=web_data["header"],
-            sections=sections.values(),
+        # Card description
+        if (
+            len(repo.description) - max_chars_description_visible
+            >= min_chars_description_hidden
+        ):
+            description = [
+                repo.description[:max_chars_description_visible],
+                repo.description[max_chars_description_visible:],
+            ]
+            id_read_more = str(count_read_more)
+            count_read_more += 1
+        else:
+            description = [repo.description, ""]
+            id_read_more = "None"
+
+        # Create the card
+        card = templates["card"].render(
+            title=repo.name,
+            tags=tags,
+            description_visible=description[0],
+            description_hidden=description[1],
+            id_read_more=id_read_more,
+            links=links,
         )
 
-    def build_website(self, resources: str, output: str):
-        """
-        Generates the ecosystem web page from data in `resources` dir, writing to `output` dir.
-        """
-        resources_dir = Path(resources)
-        html = self._build_html(*self._load_from_file(resources_dir))
-        with open(Path(output, "index.html"), "w") as f:
-            f.write(html)
+        # Adding the card to a section
+        sections[repo.group]["html"] += card
 
+    return templates["website"].render(
+        header=web_data["header"],
+        sections=sections.values(),
+    )

--- a/ecosystem/cli/website.py
+++ b/ecosystem/cli/website.py
@@ -7,6 +7,7 @@ from jinja2 import Environment, PackageLoader
 
 from ecosystem.daos import DAO
 
+
 def build_website(resources: str, output: str):
     """
     Generates the ecosystem web page from data in `resources` dir, writing to `output` dir.
@@ -15,6 +16,7 @@ def build_website(resources: str, output: str):
     html = _build_html(*_load_from_file(resources_dir))
     with open(Path(output, "index.html"), "w") as file:
         file.write(html)
+
 
 def _load_from_file(resources_dir: Path):
     """
@@ -52,6 +54,7 @@ def _load_from_file(resources_dir: Path):
         "link": environment.get_template("link.html.jinja"),
     }
     return projects, web_data, label_descriptions, templates
+
 
 def _build_html(projects, web_data, label_descriptions, templates) -> str:
     """

--- a/ecosystem/cli/website.py
+++ b/ecosystem/cli/website.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import json
 import toml
 
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, PackageLoader
 
 from ecosystem.daos import DAO
 
@@ -44,7 +44,7 @@ def _load_from_file(resources_dir: Path):
     web_data = toml.loads((resources_dir / "website.toml").read_text())
 
     # Jinja templates
-    environment = Environment(loader=FileSystemLoader("ecosystem/html_templates/"))
+    environment = Environment(loader=PackageLoader("ecosystem", "html_templates/"))
     templates = {
         "website": environment.get_template("webpage.html.jinja"),
         "card": environment.get_template("card.html.jinja"),

--- a/ecosystem/cli/website.py
+++ b/ecosystem/cli/website.py
@@ -24,9 +24,7 @@ def build_website(resources: str, output: str) -> None:
 
 def _load_from_file(
     resources_dir: Path,
-) -> tuple[
-    list[Repository], dict[str, Any], dict[str, str], dict[str, Template]
-]:
+) -> tuple[list[Repository], dict[str, Any], dict[str, str], dict[str, Template]]:
     """
     Loads website data from file.
     Returns:

--- a/ecosystem/cli/website.py
+++ b/ecosystem/cli/website.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 
 from pathlib import Path
+from typing import Any
 import json
 import toml
 
@@ -24,7 +25,7 @@ def build_website(resources: str, output: str) -> None:
 def _load_from_file(
     resources_dir: Path,
 ) -> tuple[
-    list[Repository], dict[str, str | dict], dict[str, str], dict[str, Template]
+    list[Repository], dict[str, Any], dict[str, str], dict[str, Template]
 ]:
     """
     Loads website data from file.

--- a/ecosystem/cli/website.py
+++ b/ecosystem/cli/website.py
@@ -14,8 +14,7 @@ def build_website(resources: str, output: str):
     """
     resources_dir = Path(resources)
     html = _build_html(*_load_from_file(resources_dir))
-    with open(Path(output, "index.html"), "w") as file:
-        file.write(html)
+    Path(output, "index.html").write_text(html)
 
 
 def _load_from_file(resources_dir: Path):

--- a/ecosystem/cli/website.py
+++ b/ecosystem/cli/website.py
@@ -1,8 +1,6 @@
 """CliWebsite class for controlling all CLI functions."""
 from pathlib import Path
-from typing import Optional
 import json
-import os
 import toml
 
 from jinja2 import Environment, FileSystemLoader
@@ -15,8 +13,8 @@ def build_website(resources: str, output: str):
     """
     resources_dir = Path(resources)
     html = _build_html(*_load_from_file(resources_dir))
-    with open(Path(output, "index.html"), "w") as f:
-        f.write(html)
+    with open(Path(output, "index.html"), "w") as file:
+        file.write(html)
 
 def _load_from_file(resources_dir: Path):
     """

--- a/ecosystem/cli/website.py
+++ b/ecosystem/cli/website.py
@@ -1,11 +1,15 @@
 """CliWebsite class for controlling all CLI functions."""
+from __future__ import annotations
+
+
 from pathlib import Path
 import json
 import toml
 
-from jinja2 import Environment, PackageLoader
+from jinja2 import Environment, PackageLoader, Template
 
 from ecosystem.daos import DAO
+from ecosystem.models.repository import Repository
 
 
 def build_website(resources: str, output: str):
@@ -17,13 +21,18 @@ def build_website(resources: str, output: str):
     Path(output, "index.html").write_text(html)
 
 
-def _load_from_file(resources_dir: Path):
+def _load_from_file(
+    resources_dir: Path,
+) -> tuple[
+    list[Repository], dict[str, str | dict], dict[str, str], dict[str, Template]
+]:
     """
-    Loads:
-        * Projects list
-        * Website strings
-        * Label descriptions
-        * Jinja templates
+    Loads website data from file.
+    Returns:
+        * Projects: List of Repository objects from `members` folder.
+        * Web data: Strings (title / descriptions etc.) from `website.toml`.
+        * Label descriptions: from `labels.json`.
+        * Jinja templates: from `html_templates` folder.
     """
     # Projects list
     dao = DAO(path=resources_dir)

--- a/ecosystem/daos/dao.py
+++ b/ecosystem/daos/dao.py
@@ -43,7 +43,7 @@ class TomlStorage:
         { url (str): repo (Repository) }
         """
         data = {}
-        for path in self.toml_dir.glob("*"):
+        for path in self.toml_dir.glob("*.toml"):
             repo = Repository.from_dict(toml.load(path))
             data[repo.url] = repo
         return data

--- a/manager.py
+++ b/manager.py
@@ -20,14 +20,14 @@ Available commands:
 """
 import fire
 
-from ecosystem.cli import CliMembers, CliWebsite, CliCI
+from ecosystem.cli import CliMembers, CliCI, build_website
 
 
 if __name__ == "__main__":
     fire.Fire(
         {
             "members": CliMembers,
-            "website": CliWebsite,
+            "build": build_website,
             "ci": CliCI,
         }
     )

--- a/manager.py
+++ b/manager.py
@@ -18,16 +18,7 @@ Available commands:
    python manager.py website build_website"
    ```
 """
-import fire
-
-from ecosystem.cli import CliMembers, CliCI, build_website
-
+from ecosystem import main
 
 if __name__ == "__main__":
-    fire.Fire(
-        {
-            "members": CliMembers,
-            "build": build_website,
-            "ci": CliCI,
-        }
-    )
+    main()

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,9 @@ with open('requirements.txt') as fp:
 setuptools.setup(
     name="ecosystem",
     description="Ecosystem",
+    entry_points = {
+        'console_scripts': ['ecosystem=ecosystem:main'],
+    },
     long_description=long_description,
     packages=setuptools.find_packages(),
     install_requires=install_requires,

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setuptools.setup(
     },
     long_description=long_description,
     packages=setuptools.find_packages(),
+    package_data={"ecosystem": ["html_templates/*.jinja"]},
     install_requires=install_requires,
     python_requires='>=3.6'
 )

--- a/tox.ini
+++ b/tox.ini
@@ -37,4 +37,4 @@ commands = black {posargs} ecosystem tests --check
 allowlist_externals = bash
 basepython = python3
 commands =
-  bash -ec "python manager.py website build_website --resources ecosystem/resources --output website"
+  bash -ec "python manager.py build --resources ecosystem/resources --output website"

--- a/tox.ini
+++ b/tox.ini
@@ -37,4 +37,4 @@ commands = black {posargs} ecosystem tests --check
 allowlist_externals = bash
 basepython = python3
 commands =
-  bash -ec "python manager.py website build_website > website/index.html"
+  bash -ec "python manager.py website build_website --resources ecosystem/resources --output website"


### PR DESCRIPTION
### Summary

Beforehand, these were hard-coded. Now you can install the `ecosystem` package from this repo, then run:

```sh
ecosystem build --resources ecosystem/resources --output website
```
