### PR TITLE
Re-add `qiskit-timeline-debugger`

### DIFF
--- a/ecosystem/resources/members/qiskit-timeline-debugger.toml
+++ b/ecosystem/resources/members/qiskit-timeline-debugger.toml
@@ -1,0 +1,9 @@
+name = "Qiskit Timeline Debugger"
+url = "https://github.com/TheGupta2012/qiskit-timeline-debugger"
+description = "A Jupyter widget to highlight the actions of the qiskit transpiler. Simply replace the transpile function with the debugger to see circuit evolution, property set changes, logs, docs, and more."
+licence = "Apache 2.0"
+labels = [ "Visualization", "Productivity", "Transpiler plugin",]
+created_at = 1674387065.334913
+updated_at = 1709296915.670992
+stars = 11
+group = "other"


### PR DESCRIPTION
### Summary

This project was accidentally removed by a bug in the testing feature in https://github.com/Qiskit/ecosystem/commit/d82513ccedbadad4647f4fb1a53f32fc515711c1.

I've edited the description to meet the new 30-word limit.
