### PR TITLE
Generalize website generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ dmypy.json
 
 # Generated files
 /website/index.html
+/website/style.css

--- a/ecosystem/cli/website.py
+++ b/ecosystem/cli/website.py
@@ -18,20 +18,23 @@ def build_website(resources: str, output: str) -> None:
     """
     Generates the ecosystem web page from data in `resources` dir, writing to `output` dir.
     """
-    projects, web_data, label_descriptions, templates, custom_css = _load_from_file(Path(resources))
+    projects, web_data, label_descriptions, templates, custom_css = _load_from_file(
+        Path(resources)
+    )
     html = _build_html(projects, web_data, label_descriptions, templates)
     Path(output).write_text(html)
 
     css = templates["css"].render(
-            custom_css=custom_css,
-            standalone=web_data.get("standalone", True)
+        custom_css=custom_css, standalone=web_data.get("standalone", True)
     )
     (Path(output).parent / "style.css").write_text(css)
 
 
 def _load_from_file(
     resources_dir: Path,
-) -> tuple[list[Repository], dict[str, Any], dict[str, str], dict[str, Template], str | None]:
+) -> tuple[
+    list[Repository], dict[str, Any], dict[str, str], dict[str, Template], str | None
+]:
     """
     Loads website data from file.
     Returns:

--- a/ecosystem/cli/website.py
+++ b/ecosystem/cli/website.py
@@ -20,7 +20,7 @@ def build_website(resources: str, output: str) -> None:
     """
     resources_dir = Path(resources)
     html = _build_html(*_load_from_file(resources_dir))
-    Path(output, "index.html").write_text(html)
+    Path(output).write_text(html)
 
 
 def _load_from_file(

--- a/ecosystem/cli/website.py
+++ b/ecosystem/cli/website.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 import json
-import toml
 import re
+import toml
 
 from jinja2 import Environment, PackageLoader, Template
 
@@ -22,7 +22,10 @@ def build_website(resources: str, output: str) -> None:
     html = _build_html(projects, web_data, label_descriptions, templates)
     Path(output).write_text(html)
 
-    css = templates["css"].render(custom_css=custom_css, standalone=web_data.get("standalone", True))
+    css = templates["css"].render(
+            custom_css=custom_css,
+            standalone=web_data.get("standalone", True)
+    )
     (Path(output).parent / "style.css").write_text(css)
 
 
@@ -75,6 +78,7 @@ def _build_html(projects, web_data, label_descriptions, templates) -> str:
     """
     Take all data needed to build the website and produce a HTML string.
     """
+    # pylint: disable=too-many-locals
     sections = {group["id"]: group for group in web_data["groups"]}
     for section in sections.values():
         section.setdefault("html", "")

--- a/ecosystem/cli/website.py
+++ b/ecosystem/cli/website.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 import json
 import toml
+import re
 
 from jinja2 import Environment, PackageLoader, Template
 
@@ -123,7 +124,9 @@ def _build_html(projects, web_data, label_descriptions, templates) -> str:
         # Adding the card to a section
         sections[repo.group]["html"] += card
 
-    return templates["website"].render(
+    html = templates["website"].render(
+        is_standalone=web_data.get("standalone", True),
         header=web_data["header"],
         sections=sections.values(),
     )
+    return re.sub(r"^\s+", "", html, flags=re.MULTILINE)

--- a/ecosystem/html_templates/style.css.jinja
+++ b/ecosystem/html_templates/style.css.jinja
@@ -1,3 +1,4 @@
+{% if standalone %}
 * {
   box-sizing: inherit;
 }
@@ -18,6 +19,7 @@ header {
   padding: 48px 0px 32px 0px;
   background-color: white;
 }
+{% endif %}
 
 .inside-header {
   padding: 0px 32px 0px 32px;
@@ -92,10 +94,12 @@ cds-tag {
   margin-bottom: 8px;
 }
 
+{% if standalone %}
 p {
   font-size: 14px;
   color: #525252;
 }
+{% endif %}
 
 .title-description {
   margin: 24px 0;
@@ -171,6 +175,7 @@ p {
   cursor: pointer;
 }
 
+{% if standalone %}
 /* ------------------------------  */
 
 @media only screen and (max-width: 1500px) {
@@ -205,3 +210,14 @@ p {
     width: auto;
   }  
 }
+{% endif %}
+
+{% if custom_css %}
+
+/* ------------ */
+/* Custom rules */
+/* ------------ */
+
+{{ custom_css }}
+
+{% endif %}

--- a/ecosystem/html_templates/style.css.jinja
+++ b/ecosystem/html_templates/style.css.jinja
@@ -19,6 +19,11 @@ header {
   padding: 48px 0px 32px 0px;
   background-color: white;
 }
+
+p {
+  font-size: 14px;
+  color: #525252;
+}
 {% endif %}
 
 .inside-header {
@@ -93,13 +98,6 @@ cds-tag {
   left: -20px;
   margin-bottom: 8px;
 }
-
-{% if standalone %}
-p {
-  font-size: 14px;
-  color: #525252;
-}
-{% endif %}
 
 .title-description {
   margin: 24px 0;

--- a/ecosystem/html_templates/webpage.html.jinja
+++ b/ecosystem/html_templates/webpage.html.jinja
@@ -1,3 +1,4 @@
+{% if is_standalone %}
 <!doctype html>
 <html lang="en">
   <head>
@@ -8,6 +9,19 @@
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{{ header.title.bold }} {{ header.title.normal }}</title>
+    <link
+      rel="stylesheet"
+      href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/themes.css"
+    />
+{% endif %}
+    <link
+      rel="stylesheet"
+      href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css"
+    />
     <script
       type="module"
       src="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/tile.min.js"
@@ -28,21 +42,12 @@
       type="module"
       src="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/tooltip.min.js"
     ></script>
-    <link
-      rel="stylesheet"
-      href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"
-    />
-    <link
-      rel="stylesheet"
-      href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/themes.css"
-    />
-    <link
-      rel="stylesheet"
-      href="https://1.www.s81c.com/common/carbon/web-components/tag/v2/latest/grid.css"
-    />
     <link rel="stylesheet" href="style.css" />
+{% if is_standalone %}
   </head>
-  <body class="cds-theme-zone-white">
+  <body>
+{% endif %}
+  <div class="cds-theme-zone-white">
     <header>
       <div class="inside-header cds--grid layout-lead-space-fixed__container">
         <div class="header-content">
@@ -113,5 +118,8 @@
       <div class="cards cds--row">{{ section.html }}</div>
     </div>
     {% endfor %}
+  </div>
+{% if is_standalone %}
   </body>
 </html>
+{% endif %}

--- a/ecosystem/html_templates/webpage.html.jinja
+++ b/ecosystem/html_templates/webpage.html.jinja
@@ -9,6 +9,8 @@
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{{ header.title.bold }} {{ header.title.normal }}</title>
+{# These two CSS files include general rules that we don't want to interfere #}
+{# with the page we're embedding in, so we only set them in standalone mode. #}
     <link
       rel="stylesheet"
       href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"

--- a/ecosystem/models/repository.py
+++ b/ecosystem/models/repository.py
@@ -16,7 +16,7 @@ class Repository(JsonSerializable):
     name: str
     url: str
     description: str
-    licence: str
+    licence: str | None = None
     contact_info: str | None = None
     alternatives: str | None = None
     affiliations: str | None = None

--- a/tox.ini
+++ b/tox.ini
@@ -37,4 +37,4 @@ commands = black {posargs} ecosystem tests --check
 allowlist_externals = bash
 basepython = python3
 commands =
-  bash -ec "python manager.py build --resources ecosystem/resources --output website"
+  bash -ec "python manager.py build --resources ecosystem/resources --output website/index.html"


### PR DESCRIPTION
### Summary

Adds the ability to generate HTML that can be embedded into a markdown document.
You may find it easier to review each commit separately.

- (3ec7a4818f56de487638a245caeb6bd639a430e8) Makes the license field optional. A license is still a requirement for ecosystem projects, this change just allows building the website if it isn't set in the database.
- (d24a4ab3720d889db3131a00e22e301a8dc05756) Add 'standalone' option to generate a page that can be embedded in another page.
  This basically means exluding the head/body tags, removing some CSS, and removing indentation (to play nicely with markdown).
- (92000f26903a3d5bcf05c3f4d08d12e52c67eb1f) Specify output filename (not just folder) in case you don't want the page to be called `index.html`.
- (e98f6e5e5a26744e29157142b5ab58d8f7bf9dbf) Add custom css capabilities. This lets users add custom CSS rules, specified in the `website.toml` file.
