### PR TITLE
Add UUID for each project

### DIFF
--- a/ecosystem/models/repository.py
+++ b/ecosystem/models/repository.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import pprint
 from datetime import datetime
 from dataclasses import dataclass
+from uuid import uuid4
 
 from .utils import JsonSerializable, new_list
 
@@ -33,10 +34,13 @@ class Repository(JsonSerializable):
     group: str | None = None
     reference_paper: str | None = None
     documentation: str | None = None
+    uuid: str | None = None
 
     def __post_init__(self):
         self.__dict__.setdefault("created_at", datetime.now().timestamp())
         self.__dict__.setdefault("updated_at", datetime.now().timestamp())
+        if self.uuid is None:
+            self.uuid = str(uuid4())
 
     @classmethod
     def from_dict(cls, dictionary: dict):

--- a/ecosystem/resources/members/QPong.toml
+++ b/ecosystem/resources/members/QPong.toml
@@ -9,3 +9,4 @@ created_at = 1678827877.979398
 updated_at = 1678827877.979398
 stars = 119
 group = "other"
+uuid = "56eb0ca6-4dd5-4954-a059-96256fd0ab26"

--- a/ecosystem/resources/members/QiskitOpt.jl.toml
+++ b/ecosystem/resources/members/QiskitOpt.jl.toml
@@ -10,3 +10,4 @@ created_at = 1673642669.650459
 updated_at = 1673642669.650464
 stars = 9
 group = "applications"
+uuid = "fd796b7d-2775-4ece-89f0-778066552014"

--- a/ecosystem/resources/members/QoptKIT.toml
+++ b/ecosystem/resources/members/QoptKIT.toml
@@ -9,3 +9,4 @@ ibm_maintained = false
 stars = 1
 group = "other"
 documentation = "https://soqcsadmin.github.io/QoptKIT/"
+uuid = "d94095eb-85cf-42ea-a70e-fa1735225b68"

--- a/ecosystem/resources/members/Quantum-MasterChef.toml
+++ b/ecosystem/resources/members/Quantum-MasterChef.toml
@@ -7,3 +7,4 @@ labels = [ "Game",]
 ibm_maintained = false
 stars = 2
 group = "other"
+uuid = "e6e7a086-9b91-47b9-be78-f9c7bc680863"

--- a/ecosystem/resources/members/RasQberry.toml
+++ b/ecosystem/resources/members/RasQberry.toml
@@ -9,3 +9,4 @@ created_at = 1674598082.072493
 updated_at = 1674598082.072494
 stars = 129
 group = "other"
+uuid = "dfa4cfd2-0ef5-4536-b7ec-47cc982ed0d9"

--- a/ecosystem/resources/members/azure-quantum-python.toml
+++ b/ecosystem/resources/members/azure-quantum-python.toml
@@ -7,3 +7,4 @@ ibm_maintained = false
 created_at = 1715084759.598566
 stars = 117
 group = "provider"
+uuid = "8abf631e-bbf0-4624-b9c7-60073981f5b0"

--- a/ecosystem/resources/members/bosonic-qiskit.toml
+++ b/ecosystem/resources/members/bosonic-qiskit.toml
@@ -8,3 +8,4 @@ created_at = 1678827878.841977
 updated_at = 1678827878.841978
 stars = 44
 group = "applications"
+uuid = "3d8fe04d-8ac0-4282-9eb6-cb458550945a"

--- a/ecosystem/resources/members/caml_qiskit.toml
+++ b/ecosystem/resources/members/caml_qiskit.toml
@@ -8,3 +8,4 @@ ibm_maintained = false
 stars = 9
 group = "other"
 documentation = "https://dakk.github.io/caml_qiskit/"
+uuid = "64fd2228-855b-4f30-9a1d-b64904ea80b4"

--- a/ecosystem/resources/members/circuit-knitting-toolbox.toml
+++ b/ecosystem/resources/members/circuit-knitting-toolbox.toml
@@ -10,3 +10,4 @@ updated_at = 1670427445.884068
 stars = 67
 group = "other"
 documentation = "https://qiskit-extensions.github.io/circuit-knitting-toolbox/"
+uuid = "b8a6cb2a-e38f-46a5-b714-37ddb1e562e4"

--- a/ecosystem/resources/members/dense-ev.toml
+++ b/ecosystem/resources/members/dense-ev.toml
@@ -9,3 +9,4 @@ ibm_maintained = false
 stars = 9
 group = "other"
 reference_paper = "https://arxiv.org/abs/2305.11847"
+uuid = "f305aa07-74a6-4af4-bb80-e0a75672f16f"

--- a/ecosystem/resources/members/dsm-swap.toml
+++ b/ecosystem/resources/members/dsm-swap.toml
@@ -8,3 +8,4 @@ created_at = 1678827878.56605
 updated_at = 1678827878.566051
 stars = 7
 group = "transpiler_plugin"
+uuid = "beaaab32-58d4-496f-8428-e6d88fa1e989"

--- a/ecosystem/resources/members/dynacir.toml
+++ b/ecosystem/resources/members/dynacir.toml
@@ -7,3 +7,4 @@ labels = [ "Transpiler plugin",]
 ibm_maintained = false
 stars = 0
 group = "transpiler_plugin"
+uuid = "ee3eb036-bc4d-4342-a36d-af262eed95e4"

--- a/ecosystem/resources/members/ffsim.toml
+++ b/ecosystem/resources/members/ffsim.toml
@@ -8,3 +8,4 @@ ibm_maintained = true
 website = "https://qiskit-community.github.io/ffsim/"
 stars = 19
 group = "applications"
+uuid = "8bbab14b-6cbb-4e09-8040-d5afd359deec"

--- a/ecosystem/resources/members/mitiq.toml
+++ b/ecosystem/resources/members/mitiq.toml
@@ -8,3 +8,4 @@ created_at = 1678827878.932437
 updated_at = 1678827878.932437
 stars = 344
 group = "other"
+uuid = "a4ba9712-0aae-4660-b2df-4e6e81abb6c4"

--- a/ecosystem/resources/members/mthree.toml
+++ b/ecosystem/resources/members/mthree.toml
@@ -10,3 +10,4 @@ created_at = 1678827878.805163
 updated_at = 1678827878.805164
 stars = 35
 group = "other"
+uuid = "875968b2-f9e9-44a9-a5dc-4db9c4805021"

--- a/ecosystem/resources/members/openqasm.toml
+++ b/ecosystem/resources/members/openqasm.toml
@@ -10,3 +10,4 @@ updated_at = 1660223774.44455
 website = "https://openqasm.com/"
 stars = 1188
 group = "other"
+uuid = "7d9112b0-06bf-43ef-85ff-9df6d3a153e1"

--- a/ecosystem/resources/members/pennylane-qiskit.toml
+++ b/ecosystem/resources/members/pennylane-qiskit.toml
@@ -8,3 +8,4 @@ created_at = 1678827878.782751
 updated_at = 1678827878.782752
 stars = 175
 group = "other"
+uuid = "cfbecefc-6cf7-49a6-99c5-049dae76fdcc"

--- a/ecosystem/resources/members/povm-toolbox.toml
+++ b/ecosystem/resources/members/povm-toolbox.toml
@@ -10,3 +10,4 @@ ibm_maintained = false
 stars = 6
 group = "other"
 documentation = "https://qiskit-community.github.io/povm-toolbox/"
+uuid = "1fb3d426-e458-4c7a-be9e-e31a758bb872"

--- a/ecosystem/resources/members/prototype-quantum-kernel-training.toml
+++ b/ecosystem/resources/members/prototype-quantum-kernel-training.toml
@@ -10,3 +10,4 @@ created_at = 1645480343.964777
 updated_at = 1645480343.964777
 stars = 39
 group = "applications"
+uuid = "6daa87ef-87ea-4dc9-aeed-3b9e8d202fd9"

--- a/ecosystem/resources/members/purplecaffeine.toml
+++ b/ecosystem/resources/members/purplecaffeine.toml
@@ -10,3 +10,4 @@ updated_at = 1688661859.080264
 stars = 6
 group = "other"
 documentation = "https://icekhan13.github.io/purplecaffeine/index.html"
+uuid = "a8fff49c-d8ee-4386-87b1-b28d31005823"

--- a/ecosystem/resources/members/pyRiemann-qiskit.toml
+++ b/ecosystem/resources/members/pyRiemann-qiskit.toml
@@ -9,3 +9,4 @@ ibm_maintained = false
 stars = 21
 group = "applications"
 documentation = "https://pyriemann-qiskit.readthedocs.io/"
+uuid = "fb1907a7-9af8-4c23-be0c-48841a36f2df"

--- a/ecosystem/resources/members/pytket-qiskit.toml
+++ b/ecosystem/resources/members/pytket-qiskit.toml
@@ -8,3 +8,4 @@ created_at = 1661869851.523229
 updated_at = 1661869851.523229
 stars = 13
 group = "other"
+uuid = "7c80aef4-96b8-4273-8d36-7d75ca209bcd"

--- a/ecosystem/resources/members/qBraid.toml
+++ b/ecosystem/resources/members/qBraid.toml
@@ -12,3 +12,4 @@ updated_at = 1690263743.56175
 website = "https://qbraid.com"
 stars = 62
 group = "other"
+uuid = "c5b19e1a-cdde-4f31-b9d2-62c7709da809"

--- a/ecosystem/resources/members/qdao.toml
+++ b/ecosystem/resources/members/qdao.toml
@@ -8,3 +8,4 @@ labels = [ "Circuit simulator",]
 ibm_maintained = false
 stars = 7
 group = "other"
+uuid = "c39a1176-0a10-41c5-9961-f6f4f5da0c6c"

--- a/ecosystem/resources/members/qiskit-aer.toml
+++ b/ecosystem/resources/members/qiskit-aer.toml
@@ -9,3 +9,4 @@ updated_at = 1636403010.377697
 stars = 467
 group = "other"
 documentation = "https://qiskit.org/ecosystem/aer"
+uuid = "474599a7-228b-446f-ae57-636fdbe8c1c6"

--- a/ecosystem/resources/members/qiskit-algorithms.toml
+++ b/ecosystem/resources/members/qiskit-algorithms.toml
@@ -9,3 +9,4 @@ ibm_maintained = false
 stars = 89
 group = "applications"
 documentation = "https://qiskit-community.github.io/qiskit-algorithms/"
+uuid = "39fba621-edbb-485b-a723-8a0760ab4b85"

--- a/ecosystem/resources/members/qiskit-alice-bob-provider.toml
+++ b/ecosystem/resources/members/qiskit-alice-bob-provider.toml
@@ -7,3 +7,4 @@ ibm_maintained = false
 created_at = 1715084994.136498
 stars = 19
 group = "provider"
+uuid = "00f82ee3-ab46-44fc-afbb-32cb34a72339"

--- a/ecosystem/resources/members/qiskit-aqt-provider.toml
+++ b/ecosystem/resources/members/qiskit-aqt-provider.toml
@@ -10,3 +10,4 @@ website = "https://www.aqt.eu/qc-systems/"
 stars = 26
 group = "provider"
 documentation = "https://qiskit-community.github.io/qiskit-aqt-provider/"
+uuid = "04f15cf5-ee50-4c77-b254-8907ed3ba407"

--- a/ecosystem/resources/members/qiskit-braket-provider.toml
+++ b/ecosystem/resources/members/qiskit-braket-provider.toml
@@ -7,3 +7,4 @@ ibm_maintained = false
 created_at = 1715085130.096724
 stars = 56
 group = "provider"
+uuid = "de20c734-6ee9-4ba0-a4f0-3e4d62ec3c2a"

--- a/ecosystem/resources/members/qiskit-classroom-converter.toml
+++ b/ecosystem/resources/members/qiskit-classroom-converter.toml
@@ -7,3 +7,4 @@ ibm_maintained = false
 website = "https://github.com/KMU-quantum-classroom"
 stars = 2
 group = "other"
+uuid = "bc3b8894-7e2b-4fa3-8cd2-550e58e4133b"

--- a/ecosystem/resources/members/qiskit-dynamics.toml
+++ b/ecosystem/resources/members/qiskit-dynamics.toml
@@ -9,3 +9,4 @@ updated_at = 1628883441.121111
 stars = 96
 group = "applications"
 documentation = "https://qiskit.org/ecosystem/dynamics/"
+uuid = "4bf110b1-5e54-4540-8338-d7d0fb7801d0"

--- a/ecosystem/resources/members/qiskit-experiments.toml
+++ b/ecosystem/resources/members/qiskit-experiments.toml
@@ -9,3 +9,4 @@ updated_at = 1661785302.25299
 stars = 149
 group = "other"
 documentation = "https://qiskit.org/ecosystem/experiments/"
+uuid = "6e94a8b7-65a7-4fee-b71e-25191203fa49"

--- a/ecosystem/resources/members/qiskit-finance.toml
+++ b/ecosystem/resources/members/qiskit-finance.toml
@@ -9,3 +9,4 @@ updated_at = 1636403009.368609
 stars = 219
 group = "applications"
 documentation = "https://qiskit-community.github.io/qiskit-finance/"
+uuid = "8ebeec26-5043-4423-9cdc-bfa92bd4ad63"

--- a/ecosystem/resources/members/qiskit-ionq.toml
+++ b/ecosystem/resources/members/qiskit-ionq.toml
@@ -10,3 +10,4 @@ created_at = 1670427446.011674
 updated_at = 1670427446.011675
 stars = 41
 group = "provider"
+uuid = "9dec814e-feb8-49c2-818a-f6a2503d38c5"

--- a/ecosystem/resources/members/qiskit-machine-learning.toml
+++ b/ecosystem/resources/members/qiskit-machine-learning.toml
@@ -9,3 +9,4 @@ updated_at = 1636403010.012956
 stars = 619
 group = "applications"
 documentation = "https://qiskit-community.github.io/qiskit-machine-learning/"
+uuid = "18986ebc-e138-4998-8c52-16359961af0a"

--- a/ecosystem/resources/members/qiskit-nature-cp2k.toml
+++ b/ecosystem/resources/members/qiskit-nature-cp2k.toml
@@ -7,3 +7,4 @@ ibm_maintained = false
 stars = 1
 group = "applications"
 reference_paper = "https://arxiv.org/abs/2404.18737"
+uuid = "a08d66f6-0ee7-446c-a121-c9c692bc0ae9"

--- a/ecosystem/resources/members/qiskit-nature-pyscf.toml
+++ b/ecosystem/resources/members/qiskit-nature-pyscf.toml
@@ -9,3 +9,4 @@ updated_at = 1678827878.723734
 stars = 18
 group = "applications"
 documentation = "https://qiskit-community.github.io/qiskit-nature-pyscf/"
+uuid = "1bfdd558-ebef-446b-aad5-1be7ecce68cd"

--- a/ecosystem/resources/members/qiskit-nature.toml
+++ b/ecosystem/resources/members/qiskit-nature.toml
@@ -9,3 +9,4 @@ updated_at = 1636403009.167082
 stars = 290
 group = "applications"
 documentation = "https://qiskit-community.github.io/qiskit-nature/"
+uuid = "768ba9e4-0aea-4046-a902-5c81051f001f"

--- a/ecosystem/resources/members/qiskit-on-iqm.toml
+++ b/ecosystem/resources/members/qiskit-on-iqm.toml
@@ -7,3 +7,4 @@ ibm_maintained = false
 created_at = 1715085233.375706
 stars = 17
 group = "provider"
+uuid = "648ef199-ace1-4c6b-ae9c-2c0578cde0d5"

--- a/ecosystem/resources/members/qiskit-optimization.toml
+++ b/ecosystem/resources/members/qiskit-optimization.toml
@@ -9,3 +9,4 @@ updated_at = 1636403009.538763
 stars = 215
 group = "applications"
 documentation = "https://qiskit-community.github.io/qiskit-optimization/"
+uuid = "3b2ff33f-b4a3-49cd-ab32-563d282cc3bf"

--- a/ecosystem/resources/members/qiskit-qec.toml
+++ b/ecosystem/resources/members/qiskit-qec.toml
@@ -8,3 +8,4 @@ created_at = 1662992390.122591
 updated_at = 1662992390.122597
 stars = 76
 group = "other"
+uuid = "f00eb2fa-f4f1-4e97-8e59-3013e424e0f5"

--- a/ecosystem/resources/members/qiskit-quantinuum-provider.toml
+++ b/ecosystem/resources/members/qiskit-quantinuum-provider.toml
@@ -7,3 +7,4 @@ ibm_maintained = false
 created_at = 1715085347.688097
 stars = 22
 group = "provider"
+uuid = "d5d174ee-cbe5-48a3-82ac-66d4cf2579c1"

--- a/ecosystem/resources/members/qiskit-qubit-reuse.toml
+++ b/ecosystem/resources/members/qiskit-qubit-reuse.toml
@@ -7,3 +7,4 @@ labels = [ "Paper implementation", "Transpiler plugin",]
 ibm_maintained = false
 stars = 13
 group = "transpiler_plugin"
+uuid = "c9369922-7e0d-4b77-b00a-329472b57a34"

--- a/ecosystem/resources/members/qiskit-qulacs.toml
+++ b/ecosystem/resources/members/qiskit-qulacs.toml
@@ -9,3 +9,4 @@ ibm_maintained = false
 stars = 8
 group = "provider"
 documentation = "https://qiskit-qulacs.netlify.app/"
+uuid = "ebd47aa6-4dda-4318-a822-dbd1597ed37a"

--- a/ecosystem/resources/members/qiskit-research.toml
+++ b/ecosystem/resources/members/qiskit-research.toml
@@ -8,3 +8,4 @@ created_at = 1662992208.202283
 updated_at = 1662992208.20229
 stars = 64
 group = "other"
+uuid = "8794efa6-808d-45a6-bee1-39f8eeb45fdf"

--- a/ecosystem/resources/members/qiskit-rigetti.toml
+++ b/ecosystem/resources/members/qiskit-rigetti.toml
@@ -8,3 +8,4 @@ created_at = 1678827878.136911
 updated_at = 1678827878.136912
 stars = 7
 group = "provider"
+uuid = "88a73f80-a247-4bb4-a6aa-f5da3ebd50c4"

--- a/ecosystem/resources/members/qiskit-sat-synthesis.toml
+++ b/ecosystem/resources/members/qiskit-sat-synthesis.toml
@@ -9,3 +9,4 @@ labels = [ "Transpiler plugin",]
 ibm_maintained = false
 stars = 2
 group = "transpiler_plugin"
+uuid = "2e6b95b1-5046-4a83-8842-c0b6ea36ec12"

--- a/ecosystem/resources/members/qiskit-scaleway.toml
+++ b/ecosystem/resources/members/qiskit-scaleway.toml
@@ -9,3 +9,4 @@ website = "https://www.scaleway.com"
 stars = 2
 group = "provider"
 documentation = "https://pypi.org/project/qiskit-scaleway/"
+uuid = "a942dc5d-c715-4b23-a9d6-4f2c3ee1d70b"

--- a/ecosystem/resources/members/qiskit-serverless.toml
+++ b/ecosystem/resources/members/qiskit-serverless.toml
@@ -9,3 +9,4 @@ created_at = 1670427445.627174
 updated_at = 1670427445.627175
 stars = 55
 group = "other"
+uuid = "d463fcf2-9e98-4d16-af3b-25ec29b650f7"

--- a/ecosystem/resources/members/qiskit-superstaq.toml
+++ b/ecosystem/resources/members/qiskit-superstaq.toml
@@ -9,3 +9,4 @@ ibm_maintained = false
 created_at = 1678827878.760089
 updated_at = 1678827878.76009
 group = "provider"
+uuid = "76ae525f-0734-405b-b4b8-421f74125fa2"

--- a/ecosystem/resources/members/qiskit-symb.toml
+++ b/ecosystem/resources/members/qiskit-symb.toml
@@ -9,3 +9,4 @@ created_at = 1680254616.930627
 updated_at = 1680254616.930632
 stars = 24
 group = "other"
+uuid = "9350b230-d7ca-4d52-b082-9d71303478b7"

--- a/ecosystem/resources/members/qlasskit.toml
+++ b/ecosystem/resources/members/qlasskit.toml
@@ -9,3 +9,4 @@ ibm_maintained = false
 website = "https://dakk.github.io/qlasskit/"
 stars = 51
 group = "other"
+uuid = "42b0f0f5-bdbd-4008-8749-955b496dab08"

--- a/ecosystem/resources/members/qmuvi.toml
+++ b/ecosystem/resources/members/qmuvi.toml
@@ -9,3 +9,4 @@ ibm_maintained = false
 stars = 14
 group = "other"
 documentation = "https://garymooney.github.io/qmuvi/"
+uuid = "9d4da903-9823-4ae3-a80c-22821b62931e"

--- a/ecosystem/resources/members/quPython.toml
+++ b/ecosystem/resources/members/quPython.toml
@@ -7,3 +7,4 @@ labels = [ "Circuit building tool", "Converter", "Software development kit",]
 ibm_maintained = false
 stars = 4
 group = "other"
+uuid = "bad95659-420a-4529-97d0-80e52532fc90"

--- a/ecosystem/resources/members/quantum-prototype-template.toml
+++ b/ecosystem/resources/members/quantum-prototype-template.toml
@@ -7,3 +7,4 @@ labels = []
 ibm_maintained = false
 stars = 40
 group = "other"
+uuid = "bb5d0da9-1523-4756-bda2-43d970b1fc51"

--- a/ecosystem/resources/members/quantuminspire.toml
+++ b/ecosystem/resources/members/quantuminspire.toml
@@ -8,3 +8,4 @@ created_at = 1678827878.401835
 updated_at = 1678827878.401836
 stars = 62
 group = "other"
+uuid = "fb1cd889-961a-4029-bb8f-229e4c4e12a4"

--- a/ecosystem/resources/members/torchquantum.toml
+++ b/ecosystem/resources/members/torchquantum.toml
@@ -8,3 +8,4 @@ created_at = 1678827878.611621
 updated_at = 1678827878.611622
 stars = 1237
 group = "applications"
+uuid = "6fefeede-f98e-44df-aea0-149827358701"

--- a/ecosystem/resources/members/vqls-prototype.toml
+++ b/ecosystem/resources/members/vqls-prototype.toml
@@ -11,3 +11,4 @@ created_at = 1683906067.55753
 updated_at = 1683906067.557535
 stars = 12
 group = "applications"
+uuid = "05140a48-184b-491e-ac3c-d613ca05b3c8"

--- a/ecosystem/resources/members/zoose-codespace.toml
+++ b/ecosystem/resources/members/zoose-codespace.toml
@@ -10,3 +10,4 @@ created_at = 1670402642.907656
 updated_at = 1670402642.907662
 stars = 0
 group = "other"
+uuid = "255ca532-6ea0-404d-a7dc-7181cca2e5bd"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -73,7 +73,9 @@ class TestCli(TestCase):
             "website": "https://qiskit.org/ecosystem/",
         }
         self.assertEqual(len(retrieved_repos), 1)
-        self.assertEqual(list(retrieved_repos)[0].to_dict(), expected)
+        retrieved = list(retrieved_repos)[0].to_dict()
+        self.assertIsInstance(retrieved.pop("uuid"), str)
+        self.assertEqual(retrieved, expected)
 
         # Issue 2
         captured_output = io.StringIO()
@@ -95,7 +97,9 @@ class TestCli(TestCase):
             "labels": [],
         }
         self.assertEqual(len(retrieved_repos), 1)
-        self.assertEqual(list(retrieved_repos)[0].to_dict(), expected)
+        retrieved = list(retrieved_repos)[0].to_dict()
+        self.assertIsInstance(retrieved.pop("uuid"), str)
+        self.assertEqual(retrieved, expected)
 
     def test_update_badges(self):
         """Tests creating badges."""


### PR DESCRIPTION
### Summary

Adds a UUID for each project so we can change project names without breaking the new ecosystem page. The "featured" section of the new page needs a robust way to refer to specific projects.

UUIDs were generated using the following code.

```python
from ecosystem.daos import DAO

dao = DAO("ecosystem/resources/")
for repo in dao.get_all():
    dao.write(repo)
```

You may find it easier to review each commit separately.