### PR TITLE
Fix URL for qiskit-dynamics docs site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 First read the overall project contributing guidelines. These are all
 included in the qiskit documentation:
 
-https://qiskit.org/documentation/contributing_to_qiskit.html
+https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md
 
 ## Joining the Ecosystem
 To join ecosystem you need to create 

--- a/ecosystem/resources/members/mthree.toml
+++ b/ecosystem/resources/members/mthree.toml
@@ -1,5 +1,6 @@
 name = "mthree"
 url = "https://github.com/Qiskit-Extensions/mthree"
+documentation = "https://qiskit-extensions.github.io/mthree/"
 description = "Matrix-free Measurement Mitigation (M3). Reduce the effects of readout errors from noisy quantum hardware."
 licence = "Apache 2.0"
 contact_info = ""

--- a/ecosystem/resources/members/qiskit-dynamics.toml
+++ b/ecosystem/resources/members/qiskit-dynamics.toml
@@ -1,5 +1,5 @@
 name = "Qiskit Dynamics"
-url = "https://github.com/Qiskit-Extensions/qiskit-dynamics"
+url = "https://github.com/qiskit-community/qiskit-dynamics"
 description = "Build, transform, and solve time-dependent quantum systems."
 licence = "Apache 2.0"
 labels = [ "Physics", "Application package",]
@@ -8,5 +8,5 @@ created_at = 1628883441.121108
 updated_at = 1628883441.121111
 stars = 97
 group = "applications"
-documentation = "https://qiskit.org/ecosystem/dynamics/"
+documentation = "https://qiskit-community.github.io/qiskit-dynamics/"
 uuid = "4bf110b1-5e54-4540-8338-d7d0fb7801d0"

--- a/ecosystem/resources/members/qiskit-experiments.toml
+++ b/ecosystem/resources/members/qiskit-experiments.toml
@@ -8,5 +8,5 @@ created_at = 1661785302.25299
 updated_at = 1661785302.25299
 stars = 152
 group = "other"
-documentation = "https://qiskit.org/ecosystem/experiments/"
+documentation = "https://qiskit-extensions.github.io/qiskit-experiments/"
 uuid = "6e94a8b7-65a7-4fee-b71e-25191203fa49"


### PR DESCRIPTION
The repo was recently moved to qiskit-community. This PR also fixes some other stale links from qiskit.org.