### PR TITLE
Fix follow-up action when a PR is closed

### DIFF
--- a/.github/workflows/ecosystem-submission.yml
+++ b/.github/workflows/ecosystem-submission.yml
@@ -61,6 +61,7 @@ jobs:
     if: >
       startsWith(github.event.issue.title, '[Submission]:')
       && github.event.action == 'closed'
+      && github.event.pull_request.merged == true
       && contains(github.event.issue.labels.*.name, 'submission')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Summary

When a submission PR is closed, an action posts a comment with information for new ecosystem members. For example, https://github.com/Qiskit/ecosystem/issues/823#issuecomment-2498899944.

The problem is that this comment is posted even when the PR is closed but wasn't merged. This PR fixes the workflow to only trigger when the PR is merged.
