### PR TITLE
Fixed code of conduct file location in submission template

### DIFF
--- a/.github/ISSUE_TEMPLATE/submission.yml
+++ b/.github/ISSUE_TEMPLATE/submission.yml
@@ -16,7 +16,7 @@ body:
           * Build on, interface with, or extend the [Qiskit SDK](https://github.com/Qiskit/qiskit) in some way.
           * Be compatible with Qiskit 1.0 (or newer).
           * Have an [OSI-approved](https://opensource.org/license?categories=popular-strong-community) open-source license (preferably Apache 2.0 or MIT).
-          * Adhere to our [code of conduct](./CODE_OF_CONDUCT.md) (you can enforce your own code of conduct in addition to this).
+          * Adhere to our [code of conduct](https://github.com/Qiskit/ecosystem/blob/main/CODE_OF_CONDUCT.md) (you can enforce your own code of conduct in addition to this).
           * Have maintainer activity within the last 6 months, such as a commit.
 
         If you have any questions, please reach out through the `#qiskit-ecosystem` channel on [Slack](https://qisk.it/join-slack).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,7 +1,7 @@
 <!-- Copyright Contributors to the Qiskit project. -->
 
 # Code of Conduct
-All members of this project agree to adhere to the Qiskit Code of Conduct listed at [https://github.com/Qiskit/qiskit/blob/master/CODE_OF_CONDUCT.md](https://github.com/Qiskit/qiskit/blob/master/CODE_OF_CONDUCT.md)
+All members of this project agree to adhere to the Qiskit Code of Conduct listed at [https://github.com/Qiskit/qiskit/blob/main/CODE_OF_CONDUCT.md](https://github.com/Qiskit/qiskit/blob/main/CODE_OF_CONDUCT.md)
 
 ----
 


### PR DESCRIPTION
Changes:
- Corrected `CODE_OF_CONDUCT.md` file location in submission template.

Why?
- Currently navigating to:
<img width="518" height="129" alt="image" src="https://github.com/user-attachments/assets/628279a1-ee32-41d5-9ca7-f3581f74f0a0" />
