### PR TITLE
Update on QuPepFold (qupepfold_ab89baa7.toml)

### DIFF
--- a/ecosystem/resources/members/qupepfold_ab89baa7.toml
+++ b/ecosystem/resources/members/qupepfold_ab89baa7.toml
@@ -1,6 +1,6 @@
 name = "QuPepFold"
 url = "https://github.com/akshayuttarkarc/QuPepFold"
-description = "A small, research-oriented toolkit that turns short amino-acid sequences into quantum bitstring encodings and exports PDB files."
+description = "Research-oriented toolkit for turning amino-acid sequences into quantum bitstring encodings. Peer-reviewed and published in PLOS ONE."
 licence = "MIT license"
 contact_info = "akshayuttarkar@gmail.com"
 affiliations = "R V College of Engineering MIT Vishwaprayag University"


### PR DESCRIPTION
Fixes #1017 

### Summary

Hi @akshayuttarkarc,

As requested, here are the changes in `QuPepFold (qupepfold_ab89baa7.toml)`. Once you review and agree with the changes, please approve this PR.

### Details and comments

The changes include:
 * added the suggested link to `reference_paper` - technically speaking, it is not documentation on how to use the software.
 *  @akshayuttarkarc correct me if I'm wrong, this software seems to fit in [the "Paper artifact" category better](https://github.com/Qiskit/ecosystem/blob/main/ecosystem/resources/labels.toml#L50-L52):
 > "Code or dataset needed to reproduce a specific paper. Probably, without long-term support."
