### PR TITLE
[codex] Add duplicate submission URL validation

### DIFF
--- a/ecosystem/validation/test_url.py
+++ b/ecosystem/validation/test_url.py
@@ -2,19 +2,63 @@
 
 # pylint: disable=missing-function-docstring, missing-class-docstring
 
+from ecosystem.request import URL
+
 
 class TestURLs:
+    @staticmethod
+    def _normalize_url(url):
+        """Normalize URLs before comparing them."""
+        return str(URL(str(url))).rstrip("/")
+
+    @classmethod
+    def _iter_urls(cls, value, path):
+        """Recursively search for URLs in nested containers."""
+        if value is None:
+            return
+
+        if isinstance(value, URL) or (
+            isinstance(value, str) and value.startswith(("http://", "https://"))
+        ):
+            yield path, value
+            return
+
+        if hasattr(value, "to_dict"):
+            value = value.to_dict()
+
+        if isinstance(value, dict):
+            for key, nested in value.items():
+                yield from cls._iter_urls(nested, f"{path}.{key}")
+            return
+
+        if isinstance(value, (list, tuple)):
+            for index, nested in enumerate(value):
+                yield from cls._iter_urls(nested, f"{path}[{index}]")
+
     @classmethod
     def get_all_urls(cls, member):
-        """recursevly search for URLs in the member data"""
-        for key, value in member.to_dict().items():
-            if isinstance(value, str) and value.startswith("http"):
-                yield getattr(member, key)
-            elif hasattr(getattr(member, key), "to_dict"):
-                yield from TestURLs.get_all_urls(getattr(member, key))
-            else:
-                continue
+        """Recursively search for all submission URLs covered by URL checks."""
+        relevant = {
+            "url": member.url,
+            "website": member.website,
+            "documentation": member.documentation,
+            "packages": member.packages,
+            "pypi": {
+                package_name: {"url": getattr(package, "url", None)}
+                for package_name, package in member.pypi.items()
+            },
+        }
+        yield from cls._iter_urls(relevant, "member")
 
     def test_http(self, member):
-        for url in TestURLs.get_all_urls(member):
+        for _, url in TestURLs.get_all_urls(member):
             assert not str(url).startswith("http:"), f"{url} is not HTTPS"
+
+    def test_duplicate_urls(self, member):
+        seen_urls = {}
+        for path, url in TestURLs.get_all_urls(member):
+            normalized = TestURLs._normalize_url(url)
+            seen_urls.setdefault(normalized, []).append(path)
+
+        duplicates = {url: paths for url, paths in seen_urls.items() if len(paths) > 1}
+        assert not duplicates, f"Duplicated URLs found: {duplicates}"

--- a/resources/checks.toml
+++ b/resources/checks.toml
@@ -45,7 +45,8 @@ importance = "RECOMMENDATION"
 title = "Do not repeat URLs in the submission"
 description = "Having the same URL for, for example member.website and member.documentation is unnecessary. Keep better fit and remove the other one."
 applies_to = "all"
-affects = ["member.website", "member.url", "member.documentation", "member.packages.*"]
+affects = ["member.website", "member.url", "member.documentation", "member.packages.*", "member.pypi.*.url"]
+checker = "test_url.py::TestURLs::test_duplicate_urls"
 category = "SUBMISSION"
 importance = "STRONG-RECOMMENDATION"
 

--- a/tests/test_validation_url.py
+++ b/tests/test_validation_url.py
@@ -1,0 +1,90 @@
+"""Tests for URL validation helpers."""
+
+from unittest import TestCase
+
+from ecosystem.member import Member
+from ecosystem.pypi import PyPIData
+from ecosystem.validation.test_url import TestURLs as URLValidationChecks
+
+
+class TestURLValidation(TestCase):
+    """Unit tests for URL validation checks."""
+
+    def test_get_all_urls_includes_packages_and_pypi_urls(self):
+        """Collect package and PyPI URLs from nested member data."""
+        member = Member(
+            name="Qiskit Banana Compiler",
+            url="https://github.com/somebody/banana-compiler",
+            packages=["https://example.org/package"],
+            pypi={
+                "banana-compiler": PyPIData(
+                    package_name="banana-compiler",
+                    url="https://pypi.org/project/banana-compiler/",
+                )
+            },
+        )
+
+        urls = list(URLValidationChecks.get_all_urls(member))
+
+        self.assertIn(
+            ("member.packages[0]", "https://example.org/package"),
+            [(path, str(url)) for path, url in urls],
+        )
+        self.assertIn(
+            (
+                "member.pypi.banana-compiler.url",
+                "https://pypi.org/project/banana-compiler/",
+            ),
+            [(path, str(url)) for path, url in urls],
+        )
+
+    def test_duplicate_urls_rejects_website_matching_repository_url(self):
+        """Reject websites that only repeat the repository URL."""
+        member = Member(
+            name="Qiskit Banana Compiler",
+            url="https://github.com/somebody/banana-compiler",
+            website="https://github.com/somebody/banana-compiler/",
+        )
+
+        with self.assertRaisesRegex(
+            AssertionError, "member.url'.*member.website|member.website'.*member.url"
+        ):
+            URLValidationChecks().test_duplicate_urls(member)
+
+    def test_duplicate_urls_rejects_website_matching_pypi_url(self):
+        """Reject websites that only repeat the PyPI project URL."""
+        member = Member(
+            name="Qiskit Banana Compiler",
+            url="https://github.com/somebody/banana-compiler",
+            website="https://pypi.org/project/banana-compiler/",
+            pypi={
+                "banana-compiler": PyPIData(
+                    package_name="banana-compiler",
+                    url="https://pypi.org/project/banana-compiler/",
+                )
+            },
+        )
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            "member.website'.*member.pypi.banana-compiler.url|"
+            "member.pypi.banana-compiler.url'.*member.website",
+        ):
+            URLValidationChecks().test_duplicate_urls(member)
+
+    def test_duplicate_urls_allows_distinct_urls(self):
+        """Allow distinct website, documentation, and package URLs."""
+        member = Member(
+            name="Qiskit Banana Compiler",
+            url="https://github.com/somebody/banana-compiler",
+            website="https://banana-compiler.org",
+            documentation="https://banana-compiler.org/docs",
+            pypi={
+                "banana-compiler": PyPIData(
+                    package_name="banana-compiler",
+                    url="https://pypi.org/project/banana-compiler/",
+                )
+            },
+        )
+
+        URLValidationChecks().test_duplicate_urls(member)


### PR DESCRIPTION
## Summary
- add a checker implementation for existing check `011` so duplicate submission URLs are flagged
- recurse through package and PyPI URLs when validating submission URLs
- add unit tests covering duplicated website URLs and nested URL collection

## Root cause
Check `011` already existed in `resources/checks.toml`, but it had no checker attached, so repeated submission URLs were never enforced. On top of that, the URL collector in `ecosystem/validation/test_url.py` only looked at shallow top-level fields, which meant package and PyPI URLs were skipped entirely.

## Fix
- implement duplicate URL detection in `ecosystem/validation/test_url.py`
- normalize URLs before comparison so trivial formatting differences like trailing slashes do not bypass the check
- include `member.pypi.*.url` in check `011` metadata
- add focused unit tests for GitHub/PyPI duplicate website cases and nested package/PyPI URL traversal

## Tests
- `python -m pytest tests/test_validation_url.py -q`
- `python -m pylint ecosystem/validation/test_url.py tests/test_validation_url.py`
- `python -m black --check ecosystem/validation/test_url.py tests/test_validation_url.py`
- inline `validate_member()` sanity check showing the duplicate-URL case fails on `test_url.py::TestURLs::test_duplicate_urls` while a distinct-URL case passes cleanly

## Notes or limitations
- I did not run the full repository test suite because upstream `tests/test_check.py` currently has a syntax error on `main`, unrelated to this patch.
- The targeted pytest runs emit a local `requests` dependency warning about the installed `urllib3`/`chardet` combination, but it did not affect the checks above.
- AI assistance disclosure: OpenAI Codex (GPT-5) was used to help prepare this contribution.

Fixes #1087
