### PR TITLE
Update "Double Quant" description

### DIFF
--- a/resources/members/doublequan_6e4e5010.toml
+++ b/resources/members/doublequan_6e4e5010.toml
@@ -1,7 +1,7 @@
 name = "Double Quant"
 submission_number = 1070
 url = "https://github.com/11D-Beyonder/double-quant"
-description = "Double Quant means (Qunat)um (Quant)itative, which is a high-performance quantum computing framework for solving quantitative finance problems."
+description = "Double Quant, (Qunat)um (Quant)itative, is a high-performance quantum computing framework for solving quantitative finance problems.
 contact_info = "ztz20001117@gmail.com"
 labels = [ "finance",]
 interface = [ "Python",]

--- a/resources/members/doublequan_6e4e5010.toml
+++ b/resources/members/doublequan_6e4e5010.toml
@@ -1,7 +1,7 @@
 name = "Double Quant"
 submission_number = 1070
 url = "https://github.com/11D-Beyonder/double-quant"
-description = "Double Quant, (Qunat)um (Quant)itative, is a high-performance quantum computing framework for solving quantitative finance problems.
+description = "A high-performance quantum computing framework for quantitative finance."
 contact_info = "ztz20001117@gmail.com"
 labels = [ "finance",]
 interface = [ "Python",]


### PR DESCRIPTION
Currently, Double Quant is under-review because:
```
[checks.014]
since = 2026-04-14T08:12:50.128851
details = "Description is 143-character long"
importance = "CRITICAL"
```

Checkup `[014]` is failiing:
```
[014]
title = "Description too long"
description = "Member description cannot be longer than 135 characters because front-end design limitations."
applies_to = "all"
affects = ["memeber.description"]
checker = "test_description.py::test_description_len_135"
category = "SUBMISSION"
importance = "CRITICAL"
```

Please @11D-Beyonder, review this suggested change.