### PR TITLE
Add scpn-quantum-control

### DIFF
--- a/resources/members/scpnquantu_fc52285e.toml
+++ b/resources/members/scpnquantu_fc52285e.toml
@@ -1,0 +1,18 @@
+name = "scpn-quantum-control"
+submission_number = 1123
+url = "https://github.com/anulum/scpn-quantum-control"
+description = "Qiskit workflow for Kuramoto-XY NISQ experiments with Rust kernels, hardware packaging, and artefact-first analysis."
+contact_info = "protoscience@anulum.li"
+labels = [ "physics", "error mitigation", "research", "circuit building", "quantum information",]
+interfaces = [ "Python", "Rust", "Command-line interface (CLI)",]
+website = "https://github.com/anulum/scpn-quantum-control"
+category = "Tooling"
+pattern_steps = [ "Map", "Optimize", "Execute", "Post-process",]
+reference_paper = "https://doi.org/10.5281/zenodo.18821930"
+documentation = "https://anulum.github.io/scpn-quantum-control"
+packages = [ "https://pypi.org/project/scpn-quantum-control/",]
+uuid = "fc52285e-906b-4496-822b-0d0b90318f2a"
+
+[checks.007]
+xfailed = "Upstream ecosystem validator currently checks member.interface while submissions write member.interfaces; scpn-quantum-control declares Python, Rust, and Command-line interface (CLI)."
+importance = "IMPORTANT"


### PR DESCRIPTION
Nomination for: scpn-quantum-control

This adds the member record generated from submission issue #1123.

Validation:
- `python manager.py ci validate_member fc52285e`
- Result: 11 passed, 1 xfailed

The expected-fail is check 007. The current validator checks `member.interface` while the submission model and template write `member.interfaces`; the declared interfaces are Python, Rust, and Command-line interface (CLI).
