### PR TITLE
Fix error message formatting in pypi.py

### DIFF
--- a/ecosystem/pypi.py
+++ b/ecosystem/pypi.py
@@ -170,7 +170,7 @@ class PyPIData(JsonSerializable):
                     f'$.releases["{str_version}"].*.upload_time_iso_8601', qiskit_json
                 )
                 if not str_dates:
-                    raise EcosystemError("Qiskit {str_version} has no release?")
+                    raise EcosystemError(f"Qiskit {str_version} has no release?")
                 last_date = max(parse_datetime(d) for d in str_dates)
                 self._all_qiskit_versions[str_version] = {"upload_at": last_date}
             with open(all_qiskit_versions_json, "w") as json_file:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixed error message formatting in pypi.py


### Details and comments
Previously it would display `{str_version}` instead of displaying actual version.