### PR TITLE
Add unit tests for ecosystem/github.py to increase code coverage from 28% to 94%

### DIFF
--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -1,5 +1,7 @@
 """Tests for ecosystem/github.py"""
 
+# pylint: disable=protected-access
+
 from unittest import TestCase
 from unittest.mock import patch
 from datetime import datetime

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -19,11 +19,6 @@ class TestGitHubDataInit(TestCase):
         self.assertEqual(gh.owner, "Qiskit")
         self.assertEqual(gh.repo, "qiskit-banana-compiler")
         self.assertIsNone(gh.tree)
-        self.assertIsNone(gh._json_repo)
-        self.assertIsNone(gh._json_events)
-        self.assertIsNone(gh._json_package_ids)
-        self.assertIsNone(gh._json_dependants)
-        self.assertIsNone(gh._json_contributors_sidebar)
 
     def test_init_with_tree(self):
         """tree argument is stored correctly."""
@@ -31,9 +26,9 @@ class TestGitHubDataInit(TestCase):
         self.assertEqual(gh.tree, "main")
 
     def test_init_with_kwargs(self):
-        """extra kwargs are stored in _kwargs"""
+        """extra kwargs are accessible as attributes"""
         gh = GitHubData(owner="Qiskit", repo="qiskit-banana-compiler", stars=100)
-        self.assertEqual(gh._kwargs["stars"], 100)
+        self.assertEqual(gh.stars, 100)
 
 
 class TestGitHubDataFromUrl(TestCase):

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -1,0 +1,224 @@
+"""Tests for ecosystem/github.py"""
+
+from unittest import TestCase
+from unittest.mock import patch
+from datetime import datetime
+from ecosystem.github import GitHubData
+from ecosystem.request import URL
+from ecosystem.error_handling import EcosystemError
+
+
+
+class TestGitHubDataInit(TestCase):
+    """Tests for GitHubData.__init__"""
+
+    def test_init_basic(self):
+        """ onwer, repo are set and all _json_* fields default to None"""
+        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
+        self.assertEqual(gh.owner, "Qiskit")
+        self.assertEqual(gh.repo, "qiskit-ecosystem")
+        self.assertIsNone(gh.tree)
+        self.assertIsNone(gh._json_repo)
+        self.assertIsNone(gh._json_events)
+        self.assertIsNone(gh._json_package_ids)
+        self.assertIsNone(gh._json_dependants)
+        self.assertIsNone(gh._json_contributors_sidebar)
+    
+    def test_init_with_tree(self):
+        """ tree argument is stored correctly."""
+        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem", tree="main")
+        self.assertEqual(gh.tree, "main")
+    
+    def test_init_with_kwargs(self):
+        """extra kwargs are stored in _kwargs"""
+        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem", stars=100)
+        self.assertEqual(gh._kwargs["stars"], 100)
+
+
+class TestGitHubDataFromUrl(TestCase):
+    """Tests for GitHubData.from_url"""
+
+    def setUp(self):
+        self.github_url = URL("https://github.com/Qiskit/qiskit-ecosystem")
+        self.gitlab_url = URL("https://gitlab.com/")
+        self.tree_url = URL("https://github.com/Qiskit/qiskit-ecosystem/tree/main")
+        self.invalid_url = URL("https://github.com/onlyone")
+        self.too_many_parts_url = URL("https://github.com/owner/repo/extra/parts")
+    
+    def test_valid_github_url(self):
+        """Valid GitHub URL creates object with correct owner, repo and no tree"""
+        gh = GitHubData.from_url(self.github_url)
+        self.assertIsNotNone(gh)
+        self.assertEqual(gh.owner, "Qiskit")
+        self.assertEqual(gh.repo, "qiskit-ecosystem")
+        self.assertIsNone(gh.tree)
+    
+    def test_non_github_url_returns_none(self):
+        """Non-GitHub URL returns None"""
+        result = GitHubData.from_url(self.gitlab_url)
+        self.assertIsNone(result)
+    
+    def test_url_with_tree_path(self):
+        """GitHub URL with /tree/ correctly splits out the tree path"""
+        gh = GitHubData.from_url(self.tree_url)
+        self.assertIsNotNone(gh)
+        self.assertEqual(gh.owner, "Qiskit")
+        self.assertEqual(gh.repo, "qiskit-ecosystem")
+        self.assertEqual(gh.tree, "main")
+    
+    def test_invalid_url_too_few_parts_raise_error(self):
+        """GitHub URL with only one path segment raises EcosystemEror"""
+        with self.assertRaises(EcosystemError):
+            GitHubData.from_url(self.invalid_url)
+    
+    def test_invalid_url_too_many_parts_raise_error(self):
+        """GitHub URL with more than two path segments raises EcosystemError"""
+        with self.assertRaises(EcosystemError):
+            GitHubData.from_url(self.too_many_parts_url)
+    
+
+class TestGitHubDataToDict(TestCase):
+    """Tests for GitHubData.to_dict"""
+    
+    def test_to_dict_has_owner_and_repo(self):
+        """to_dict always includes owner and repo"""
+        gh =GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
+        d = gh.to_dict()
+        self.assertIn("owner", d)
+        self.assertIn("repo", d)
+        self.assertEqual(d["owner"], "Qiskit")
+        self.assertEqual(d["repo"], "qiskit-ecosystem")
+    
+    def test_to_dict_excludes_none_values(self):
+        """Keys with None values are not included in the dictionary"""
+        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
+        d = gh.to_dict()
+        self.assertNotIn("tree", d)
+        self.assertNotIn("homepage", d)
+    
+    def test_to_dict_includes_tree_when_set(self):
+        """tree appears in dict when provided"""
+        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem", tree="main")
+        d = gh.to_dict()
+        self.assertIn("tree", d)
+        self.assertEqual(d["tree"], "main")
+
+
+class TestGitHubDataGetattr(TestCase):
+    """Tests for GitHubData.__getattr__"""
+    
+    def setUp(self):
+        self.gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
+    
+    def test_getattr_alias_stars(self):
+        """gh.stars resolves via alias stargazers_count from _json_repo"""
+        self.gh._json_repo = {"stargazers_count": 42}
+        self.assertEqual(self.gh.stars, 42)
+    
+    def test_getattr_alias_url(self):
+        """gh.url resolves via alias html_url from _json_repo"""
+        self.gh._json_repo = {"html_url": "https://github.com/Qiskit/qiskit-ecosystem"}
+        self.assertEqual(self.gh.url, "https://github.com/Qiskit/qiskit-ecosystem")
+    
+    def test_getattr_alias_last_commit(self):
+        """gh.last_commit resolves via alias pushed_at and returns a datetime"""
+        self.gh._json_repo = {"pushed_at": "2024-01-15T10:30:00"}
+        self.assertIsInstance(self.gh.last_commit, datetime)
+    
+    def test_getattr_description_truncated(self):
+        """description longer than 135 characters is truncated with ellipsis"""
+        self.gh._json_repo = {"description": "x" * 200}
+        result = self.gh.description
+        self.assertTrue(result.endswith("..."))
+    
+    def test_getattr_missing_key_raises_attribute_error(self):
+        """accessing a key not in _json_repo raises AttributeError"""
+        self.gh._json_repo = {"some_key": "value"}
+        with self.assertRaises(AttributeError):
+            _ = self.gh.nonexistent
+    
+    def test_getattr_from_kwargs_when_no_json(self):
+        """returns value from _kwargs when _json_repo is None"""
+        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem", stars=99)
+        self.assertEqual(gh._kwargs["stars"], 99)
+    
+    def test_getattr_missing_raises_attribute_error_no_json(self):
+        """raises AttributeError when key absent from both _json_repo and _kwargs"""
+        with self.assertRaises(AttributeError):
+            _ = self.gh.nonexistent
+
+
+class TestGitHubDataUpdateOwnerRepo(TestCase):
+    """Tests for GitHubData.update_owner_repo"""
+    
+    def test_update_owner_repo_no_change(self):
+        """owner and repo unchanged when JSON matches"""
+        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
+        gh._json_repo = {"owner": {"login": "Qiskit"}, "name": "qiskit-ecosystem"}
+        gh.update_owner_repo()
+        self.assertEqual(gh.owner, "Qiskit")
+        self.assertEqual(gh.repo, "qiskit-ecosystem")
+    
+    def test_update_owner_repo_detects_rename(self):
+        """owner and repo updated when JSON has different values"""
+        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
+        gh._json_repo = {"owner": {"login": "NewOwner"}, "name": "new-repo"}
+        gh.update_owner_repo()
+        self.assertEqual(gh.owner, "NewOwner")
+        self.assertEqual(gh.repo, "new-repo")
+
+
+class TestGitHubDataUpdateJson(TestCase):
+    """Tests for GitHubData.update_json"""
+    
+    def test_update_json_populates_json_repo(self):
+        """after update_json, _json_repo is set"""
+        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
+        with patch("ecosystem.github.request_json") as mock_request:
+            mock_request.return_value = {"data": {}, "_requested_at_": "2024-01-01"}
+            gh._json_package_ids = {}
+            gh.update_json()
+            self.assertIsNotNone(gh._json_repo)
+    
+    def test_update_json_fetches_dependants_per_package(self):
+        """fetches dependants for each package returned"""
+        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
+        fake_response = {"data": {}, "_requested_at_": "2024-01-01"}
+        with patch("ecosystem.github.request_json") as mock_request:
+            mock_request.side_effect =[
+                fake_response,  # for _json_repo
+                fake_response,  # for _json_events
+                fake_response,  # for _json_contributors_sidebar
+                {"pkg1": "id123"}, # for _json_package_ids
+                fake_response, # for dependants of pkg1
+            ]
+            gh.update_json()
+            self.assertIn("pkg1", gh._json_dependants)
+
+class TestGitHubDataProperties(TestCase):
+    """Tests for dependants, contributors, and property methods"""
+
+    def test_dependants_refresh_calls_update_json(self):
+        """refresh=True triggers update_json()"""
+        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
+        with patch.object(GitHubData, "update_json") as mock_update:
+            gh.dependants(refresh=True)
+            mock_update.assert_called_once()
+
+    def test_total_dependent_repositories_sums_correctly(self):
+        """sums repositories across all packages in dependants"""
+        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
+        gh._json_dependants = {
+            "pkg1": {"repositories": 10},
+            "pkg2": {"repositories": 5},
+        }
+        self.assertEqual(gh.total_dependent_repositories, 15)
+
+    def test_total_dependent_packages_sums_correctly(self):
+        """sums packages across all packages in dependants"""
+        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
+        gh._json_dependants = {
+            "pkg1": {"packages": 3},
+            "pkg2": {"packages": 7},
+        }
+        self.assertEqual(gh.total_dependent_packages, 10)

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -8,12 +8,11 @@ from ecosystem.request import URL
 from ecosystem.error_handling import EcosystemError
 
 
-
 class TestGitHubDataInit(TestCase):
     """Tests for GitHubData.__init__"""
 
     def test_init_basic(self):
-        """ onwer, repo are set and all _json_* fields default to None"""
+        """onwer, repo are set and all _json_* fields default to None"""
         gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
         self.assertEqual(gh.owner, "Qiskit")
         self.assertEqual(gh.repo, "qiskit-ecosystem")
@@ -23,12 +22,12 @@ class TestGitHubDataInit(TestCase):
         self.assertIsNone(gh._json_package_ids)
         self.assertIsNone(gh._json_dependants)
         self.assertIsNone(gh._json_contributors_sidebar)
-    
+
     def test_init_with_tree(self):
-        """ tree argument is stored correctly."""
+        """tree argument is stored correctly."""
         gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem", tree="main")
         self.assertEqual(gh.tree, "main")
-    
+
     def test_init_with_kwargs(self):
         """extra kwargs are stored in _kwargs"""
         gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem", stars=100)
@@ -44,7 +43,7 @@ class TestGitHubDataFromUrl(TestCase):
         self.tree_url = URL("https://github.com/Qiskit/qiskit-ecosystem/tree/main")
         self.invalid_url = URL("https://github.com/onlyone")
         self.too_many_parts_url = URL("https://github.com/owner/repo/extra/parts")
-    
+
     def test_valid_github_url(self):
         """Valid GitHub URL creates object with correct owner, repo and no tree"""
         gh = GitHubData.from_url(self.github_url)
@@ -52,12 +51,12 @@ class TestGitHubDataFromUrl(TestCase):
         self.assertEqual(gh.owner, "Qiskit")
         self.assertEqual(gh.repo, "qiskit-ecosystem")
         self.assertIsNone(gh.tree)
-    
+
     def test_non_github_url_returns_none(self):
         """Non-GitHub URL returns None"""
         result = GitHubData.from_url(self.gitlab_url)
         self.assertIsNone(result)
-    
+
     def test_url_with_tree_path(self):
         """GitHub URL with /tree/ correctly splits out the tree path"""
         gh = GitHubData.from_url(self.tree_url)
@@ -65,37 +64,37 @@ class TestGitHubDataFromUrl(TestCase):
         self.assertEqual(gh.owner, "Qiskit")
         self.assertEqual(gh.repo, "qiskit-ecosystem")
         self.assertEqual(gh.tree, "main")
-    
+
     def test_invalid_url_too_few_parts_raise_error(self):
         """GitHub URL with only one path segment raises EcosystemEror"""
         with self.assertRaises(EcosystemError):
             GitHubData.from_url(self.invalid_url)
-    
+
     def test_invalid_url_too_many_parts_raise_error(self):
         """GitHub URL with more than two path segments raises EcosystemError"""
         with self.assertRaises(EcosystemError):
             GitHubData.from_url(self.too_many_parts_url)
-    
+
 
 class TestGitHubDataToDict(TestCase):
     """Tests for GitHubData.to_dict"""
-    
+
     def test_to_dict_has_owner_and_repo(self):
         """to_dict always includes owner and repo"""
-        gh =GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
+        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
         d = gh.to_dict()
         self.assertIn("owner", d)
         self.assertIn("repo", d)
         self.assertEqual(d["owner"], "Qiskit")
         self.assertEqual(d["repo"], "qiskit-ecosystem")
-    
+
     def test_to_dict_excludes_none_values(self):
         """Keys with None values are not included in the dictionary"""
         gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
         d = gh.to_dict()
         self.assertNotIn("tree", d)
         self.assertNotIn("homepage", d)
-    
+
     def test_to_dict_includes_tree_when_set(self):
         """tree appears in dict when provided"""
         gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem", tree="main")
@@ -106,42 +105,42 @@ class TestGitHubDataToDict(TestCase):
 
 class TestGitHubDataGetattr(TestCase):
     """Tests for GitHubData.__getattr__"""
-    
+
     def setUp(self):
         self.gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
-    
+
     def test_getattr_alias_stars(self):
         """gh.stars resolves via alias stargazers_count from _json_repo"""
         self.gh._json_repo = {"stargazers_count": 42}
         self.assertEqual(self.gh.stars, 42)
-    
+
     def test_getattr_alias_url(self):
         """gh.url resolves via alias html_url from _json_repo"""
         self.gh._json_repo = {"html_url": "https://github.com/Qiskit/qiskit-ecosystem"}
         self.assertEqual(self.gh.url, "https://github.com/Qiskit/qiskit-ecosystem")
-    
+
     def test_getattr_alias_last_commit(self):
         """gh.last_commit resolves via alias pushed_at and returns a datetime"""
         self.gh._json_repo = {"pushed_at": "2024-01-15T10:30:00"}
         self.assertIsInstance(self.gh.last_commit, datetime)
-    
+
     def test_getattr_description_truncated(self):
         """description longer than 135 characters is truncated with ellipsis"""
         self.gh._json_repo = {"description": "x" * 200}
         result = self.gh.description
         self.assertTrue(result.endswith("..."))
-    
+
     def test_getattr_missing_key_raises_attribute_error(self):
         """accessing a key not in _json_repo raises AttributeError"""
         self.gh._json_repo = {"some_key": "value"}
         with self.assertRaises(AttributeError):
             _ = self.gh.nonexistent
-    
+
     def test_getattr_from_kwargs_when_no_json(self):
         """returns value from _kwargs when _json_repo is None"""
         gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem", stars=99)
         self.assertEqual(gh._kwargs["stars"], 99)
-    
+
     def test_getattr_missing_raises_attribute_error_no_json(self):
         """raises AttributeError when key absent from both _json_repo and _kwargs"""
         with self.assertRaises(AttributeError):
@@ -150,7 +149,7 @@ class TestGitHubDataGetattr(TestCase):
 
 class TestGitHubDataUpdateOwnerRepo(TestCase):
     """Tests for GitHubData.update_owner_repo"""
-    
+
     def test_update_owner_repo_no_change(self):
         """owner and repo unchanged when JSON matches"""
         gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
@@ -158,7 +157,7 @@ class TestGitHubDataUpdateOwnerRepo(TestCase):
         gh.update_owner_repo()
         self.assertEqual(gh.owner, "Qiskit")
         self.assertEqual(gh.repo, "qiskit-ecosystem")
-    
+
     def test_update_owner_repo_detects_rename(self):
         """owner and repo updated when JSON has different values"""
         gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
@@ -170,7 +169,7 @@ class TestGitHubDataUpdateOwnerRepo(TestCase):
 
 class TestGitHubDataUpdateJson(TestCase):
     """Tests for GitHubData.update_json"""
-    
+
     def test_update_json_populates_json_repo(self):
         """after update_json, _json_repo is set"""
         gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
@@ -179,21 +178,22 @@ class TestGitHubDataUpdateJson(TestCase):
             gh._json_package_ids = {}
             gh.update_json()
             self.assertIsNotNone(gh._json_repo)
-    
+
     def test_update_json_fetches_dependants_per_package(self):
         """fetches dependants for each package returned"""
         gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
         fake_response = {"data": {}, "_requested_at_": "2024-01-01"}
         with patch("ecosystem.github.request_json") as mock_request:
-            mock_request.side_effect =[
+            mock_request.side_effect = [
                 fake_response,  # for _json_repo
                 fake_response,  # for _json_events
                 fake_response,  # for _json_contributors_sidebar
-                {"pkg1": "id123"}, # for _json_package_ids
-                fake_response, # for dependants of pkg1
+                {"pkg1": "id123"},  # for _json_package_ids
+                fake_response,  # for dependants of pkg1
             ]
             gh.update_json()
             self.assertIn("pkg1", gh._json_dependants)
+
 
 class TestGitHubDataProperties(TestCase):
     """Tests for dependants, contributors, and property methods"""

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -1,7 +1,5 @@
 """Tests for ecosystem/github.py"""
 
-# pylint: disable=protected-access
-
 from unittest import TestCase
 from unittest.mock import patch
 from datetime import datetime
@@ -112,39 +110,74 @@ class TestGitHubDataGetattr(TestCase):
 
     def test_getattr_alias_stars(self):
         """gh.stars resolves via alias stargazers_count from _json_repo"""
-        self.gh._json_repo = {"stargazers_count": 42}
+        with patch("ecosystem.github.request_json") as mock_request:
+            mock_request.side_effect = [
+                {"stargazers_count": 42, "_requested_at_": "2024-01-01"},
+                {"data": [], "_requested_at_": "2024-01-01"},
+                None,
+                {},
+            ]
+            self.gh.update_json()
         self.assertEqual(self.gh.stars, 42)
 
     def test_getattr_alias_url(self):
         """gh.url resolves via alias html_url from _json_repo"""
-        self.gh._json_repo = {
-            "html_url": "https://github.com/Qiskit/qiskit-banana-compiler"
-        }
+        with patch("ecosystem.github.request_json") as mock_request:
+            mock_request.side_effect = [
+                {
+                    "html_url": "https://github.com/Qiskit/qiskit-banana-compiler",
+                    "_requested_at_": "2024-01-01",
+                },
+                {"data": [], "_requested_at_": "2024-01-01"},
+                None,
+                {},
+            ]
+            self.gh.update_json()
         self.assertEqual(
             self.gh.url, "https://github.com/Qiskit/qiskit-banana-compiler"
         )
 
     def test_getattr_alias_last_commit(self):
         """gh.last_commit resolves via alias pushed_at and returns a datetime"""
-        self.gh._json_repo = {"pushed_at": "2024-01-15T10:30:00"}
+        with patch("ecosystem.github.request_json") as mock_request:
+            mock_request.side_effect = [
+                {"pushed_at": "2024-01-01T12:00:00", "_requested_at_": "2024-01-01"},
+                {"data": [], "_requested_at_": "2024-01-01"},
+                None,
+                {},
+            ]
+            self.gh.update_json()
         self.assertIsInstance(self.gh.last_commit, datetime)
 
     def test_getattr_description_truncated(self):
         """description longer than 135 characters is truncated with ellipsis"""
-        self.gh._json_repo = {"description": "x" * 200}
-        result = self.gh.description
-        self.assertTrue(result.endswith("..."))
+        with patch("ecosystem.github.request_json") as mock_request:
+            mock_request.side_effect = [
+                {"description": "x" * 200, "_requested_at_": "2024-01-01"},
+                {"data": [], "_requested_at_": "2024-01-01"},
+                None,
+                {},
+            ]
+            self.gh.update_json()
+        self.assertTrue(self.gh.description.endswith("..."))
 
     def test_getattr_missing_key_raises_attribute_error(self):
         """accessing a key not in _json_repo raises AttributeError"""
-        self.gh._json_repo = {"some_key": "value"}
+        with patch("ecosystem.github.request_json") as mock_request:
+            mock_request.side_effect = [
+                {"some_key": "value", "_requested_at_": "2024-01-01"},
+                {"data": [], "_requested_at_": "2024-01-01"},
+                None,
+                {},
+            ]
+            self.gh.update_json()
         with self.assertRaises(AttributeError):
             _ = self.gh.nonexistent
 
     def test_getattr_from_kwargs_when_no_json(self):
         """returns value from _kwargs when _json_repo is None"""
         gh = GitHubData(owner="Qiskit", repo="qiskit-banana-compiler", stars=99)
-        self.assertEqual(gh._kwargs["stars"], 99)
+        self.assertEqual(gh.stars, 99)
 
     def test_getattr_missing_raises_attribute_error_no_json(self):
         """raises AttributeError when key absent from both _json_repo and _kwargs"""
@@ -158,7 +191,18 @@ class TestGitHubDataUpdateOwnerRepo(TestCase):
     def test_update_owner_repo_no_change(self):
         """owner and repo unchanged when JSON matches"""
         gh = GitHubData(owner="Qiskit", repo="qiskit-banana-compiler")
-        gh._json_repo = {"owner": {"login": "Qiskit"}, "name": "qiskit-banana-compiler"}
+        with patch("ecosystem.github.request_json") as mock_request:
+            mock_request.side_effect = [
+                {
+                    "owner": {"login": "Qiskit"},
+                    "name": "qiskit-banana-compiler",
+                    "_requested_at_": "2024-01-01",
+                },
+                {"data": [], "_requested_at_": "2024-01-01"},
+                None,
+                {},
+            ]
+            gh.update_json()
         gh.update_owner_repo()
         self.assertEqual(gh.owner, "Qiskit")
         self.assertEqual(gh.repo, "qiskit-banana-compiler")
@@ -166,7 +210,18 @@ class TestGitHubDataUpdateOwnerRepo(TestCase):
     def test_update_owner_repo_detects_rename(self):
         """owner and repo updated when JSON has different values"""
         gh = GitHubData(owner="Qiskit", repo="qiskit-banana-compiler")
-        gh._json_repo = {"owner": {"login": "NewOwner"}, "name": "new-repo"}
+        with patch("ecosystem.github.request_json") as mock_request:
+            mock_request.side_effect = [
+                {
+                    "owner": {"login": "NewOwner"},
+                    "name": "new-repo",
+                    "_requested_at_": "2024-01-01",
+                },
+                {"data": [], "_requested_at_": "2024-01-01"},
+                None,
+                {},
+            ]
+            gh.update_json()
         gh.update_owner_repo()
         self.assertEqual(gh.owner, "NewOwner")
         self.assertEqual(gh.repo, "new-repo")
@@ -176,13 +231,17 @@ class TestGitHubDataUpdateJson(TestCase):
     """Tests for GitHubData.update_json"""
 
     def test_update_json_populates_json_repo(self):
-        """after update_json, _json_repo is set"""
+        """after update_json, data is accessible via public attributes"""
         gh = GitHubData(owner="Qiskit", repo="qiskit-banana-compiler")
         with patch("ecosystem.github.request_json") as mock_request:
-            mock_request.return_value = {"data": {}, "_requested_at_": "2024-01-01"}
-            gh._json_package_ids = {}
+            mock_request.side_effect = [
+                {"stargazers_count": 42, "_requested_at_": "2024-01-01"},
+                {"data": [], "_requested_at_": "2024-01-01"},
+                None,
+                {},
+            ]
             gh.update_json()
-            self.assertIsNotNone(gh._json_repo)
+        self.assertEqual(gh.stars, 42)
 
     def test_update_json_fetches_dependants_per_package(self):
         """fetches dependants for each package returned"""
@@ -197,7 +256,7 @@ class TestGitHubDataUpdateJson(TestCase):
                 fake_response,  # for dependants of pkg1
             ]
             gh.update_json()
-            self.assertIn("pkg1", gh._json_dependants)
+            self.assertIn("pkg1", gh.dependants())
 
 
 class TestGitHubDataProperties(TestCase):
@@ -213,17 +272,29 @@ class TestGitHubDataProperties(TestCase):
     def test_total_dependent_repositories_sums_correctly(self):
         """sums repositories across all packages in dependants"""
         gh = GitHubData(owner="Qiskit", repo="qiskit-banana-compiler")
-        gh._json_dependants = {
-            "pkg1": {"repositories": 10},
-            "pkg2": {"repositories": 5},
-        }
+        with patch("ecosystem.github.request_json") as mock_request:
+            mock_request.side_effect = [
+                {"_requested_at_": "2024-01-01"},
+                {"data": [], "_requested_at_": "2024-01-01"},
+                None,
+                {"pkg1": "id1", "pkg2": "id2"},
+                {"repositories": 10, "_requested_at_": "2024-01-01"},
+                {"repositories": 5, "_requested_at_": "2024-01-01"},
+            ]
+            gh.update_json()
         self.assertEqual(gh.total_dependent_repositories, 15)
 
     def test_total_dependent_packages_sums_correctly(self):
         """sums packages across all packages in dependants"""
         gh = GitHubData(owner="Qiskit", repo="qiskit-banana-compiler")
-        gh._json_dependants = {
-            "pkg1": {"packages": 3},
-            "pkg2": {"packages": 7},
-        }
+        with patch("ecosystem.github.request_json") as mock_request:
+            mock_request.side_effect = [
+                {"_requested_at_": "2024-01-01"},
+                {"data": [], "_requested_at_": "2024-01-01"},
+                None,
+                {"pkg1": "id1", "pkg2": "id2"},
+                {"packages": 3, "_requested_at_": "2024-01-01"},
+                {"packages": 7, "_requested_at_": "2024-01-01"},
+            ]
+            gh.update_json()
         self.assertEqual(gh.total_dependent_packages, 10)

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -1,3 +1,15 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 """Tests for ecosystem/github.py"""
 
 from unittest import TestCase

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -2,7 +2,7 @@
 
 from unittest import TestCase
 from unittest.mock import patch
-from datetime import datetime
+from datetime import date
 from ecosystem.github import GitHubData
 from ecosystem.request import URL
 from ecosystem.error_handling import EcosystemError
@@ -138,7 +138,7 @@ class TestGitHubDataGetattr(TestCase):
         )
 
     def test_getattr_alias_last_commit(self):
-        """gh.last_commit resolves via alias pushed_at and returns a datetime"""
+        """gh.last_commit resolves via alias pushed_at and returns a date"""
         with patch("ecosystem.github.request_json") as mock_request:
             mock_request.side_effect = [
                 {"pushed_at": "2024-01-01T12:00:00", "_requested_at_": "2024-01-01"},
@@ -147,7 +147,7 @@ class TestGitHubDataGetattr(TestCase):
                 {},
             ]
             self.gh.update_json()
-        self.assertIsInstance(self.gh.last_commit, datetime)
+        self.assertIsInstance(self.gh.last_commit, date)
 
     def test_getattr_description_truncated(self):
         """description longer than 135 characters is truncated with ellipsis"""

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -11,7 +11,7 @@ from ecosystem.error_handling import EcosystemError
 
 
 class TestGitHubDataInit(TestCase):
-    """Tests for GitHubData.__init__"""
+    """Tests for GitHubData builder"""
 
     def test_init_basic(self):
         """onwer, repo are set and all _json_* fields default to None"""

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -15,9 +15,9 @@ class TestGitHubDataInit(TestCase):
 
     def test_init_basic(self):
         """onwer, repo are set and all _json_* fields default to None"""
-        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
+        gh = GitHubData(owner="Qiskit", repo="qiskit-banana-compiler")
         self.assertEqual(gh.owner, "Qiskit")
-        self.assertEqual(gh.repo, "qiskit-ecosystem")
+        self.assertEqual(gh.repo, "qiskit-banana-compiler")
         self.assertIsNone(gh.tree)
         self.assertIsNone(gh._json_repo)
         self.assertIsNone(gh._json_events)
@@ -27,12 +27,12 @@ class TestGitHubDataInit(TestCase):
 
     def test_init_with_tree(self):
         """tree argument is stored correctly."""
-        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem", tree="main")
+        gh = GitHubData(owner="Qiskit", repo="qiskit-banana-compiler", tree="main")
         self.assertEqual(gh.tree, "main")
 
     def test_init_with_kwargs(self):
         """extra kwargs are stored in _kwargs"""
-        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem", stars=100)
+        gh = GitHubData(owner="Qiskit", repo="qiskit-banana-compiler", stars=100)
         self.assertEqual(gh._kwargs["stars"], 100)
 
 
@@ -40,18 +40,22 @@ class TestGitHubDataFromUrl(TestCase):
     """Tests for GitHubData.from_url"""
 
     def setUp(self):
-        self.github_url = URL("https://github.com/Qiskit/qiskit-ecosystem")
+        self.github_url = URL("https://github.com/Qiskit/qiskit-banana-compiler")
         self.gitlab_url = URL("https://gitlab.com/")
-        self.tree_url = URL("https://github.com/Qiskit/qiskit-ecosystem/tree/main")
-        self.invalid_url = URL("https://github.com/onlyone")
-        self.too_many_parts_url = URL("https://github.com/owner/repo/extra/parts")
+        self.tree_url = URL(
+            "https://github.com/Qiskit/qiskit-banana-compiler/tree/main"
+        )
+        self.invalid_url = URL("https://github.com/Qiskit")
+        self.too_many_parts_url = URL(
+            "https://github.com/Qiskit/qiskit-banana-compiler/extra/parts"
+        )
 
     def test_valid_github_url(self):
         """Valid GitHub URL creates object with correct owner, repo and no tree"""
         gh = GitHubData.from_url(self.github_url)
         self.assertIsNotNone(gh)
         self.assertEqual(gh.owner, "Qiskit")
-        self.assertEqual(gh.repo, "qiskit-ecosystem")
+        self.assertEqual(gh.repo, "qiskit-banana-compiler")
         self.assertIsNone(gh.tree)
 
     def test_non_github_url_returns_none(self):
@@ -64,7 +68,7 @@ class TestGitHubDataFromUrl(TestCase):
         gh = GitHubData.from_url(self.tree_url)
         self.assertIsNotNone(gh)
         self.assertEqual(gh.owner, "Qiskit")
-        self.assertEqual(gh.repo, "qiskit-ecosystem")
+        self.assertEqual(gh.repo, "qiskit-banana-compiler")
         self.assertEqual(gh.tree, "main")
 
     def test_invalid_url_too_few_parts_raise_error(self):
@@ -83,23 +87,23 @@ class TestGitHubDataToDict(TestCase):
 
     def test_to_dict_has_owner_and_repo(self):
         """to_dict always includes owner and repo"""
-        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
+        gh = GitHubData(owner="Qiskit", repo="qiskit-banana-compiler")
         d = gh.to_dict()
         self.assertIn("owner", d)
         self.assertIn("repo", d)
         self.assertEqual(d["owner"], "Qiskit")
-        self.assertEqual(d["repo"], "qiskit-ecosystem")
+        self.assertEqual(d["repo"], "qiskit-banana-compiler")
 
     def test_to_dict_excludes_none_values(self):
         """Keys with None values are not included in the dictionary"""
-        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
+        gh = GitHubData(owner="Qiskit", repo="qiskit-banana-compiler")
         d = gh.to_dict()
         self.assertNotIn("tree", d)
         self.assertNotIn("homepage", d)
 
     def test_to_dict_includes_tree_when_set(self):
         """tree appears in dict when provided"""
-        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem", tree="main")
+        gh = GitHubData(owner="Qiskit", repo="qiskit-banana-compiler", tree="main")
         d = gh.to_dict()
         self.assertIn("tree", d)
         self.assertEqual(d["tree"], "main")
@@ -109,7 +113,7 @@ class TestGitHubDataGetattr(TestCase):
     """Tests for GitHubData.__getattr__"""
 
     def setUp(self):
-        self.gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
+        self.gh = GitHubData(owner="Qiskit", repo="qiskit-banana-compiler")
 
     def test_getattr_alias_stars(self):
         """gh.stars resolves via alias stargazers_count from _json_repo"""
@@ -118,8 +122,12 @@ class TestGitHubDataGetattr(TestCase):
 
     def test_getattr_alias_url(self):
         """gh.url resolves via alias html_url from _json_repo"""
-        self.gh._json_repo = {"html_url": "https://github.com/Qiskit/qiskit-ecosystem"}
-        self.assertEqual(self.gh.url, "https://github.com/Qiskit/qiskit-ecosystem")
+        self.gh._json_repo = {
+            "html_url": "https://github.com/Qiskit/qiskit-banana-compiler"
+        }
+        self.assertEqual(
+            self.gh.url, "https://github.com/Qiskit/qiskit-banana-compiler"
+        )
 
     def test_getattr_alias_last_commit(self):
         """gh.last_commit resolves via alias pushed_at and returns a datetime"""
@@ -140,7 +148,7 @@ class TestGitHubDataGetattr(TestCase):
 
     def test_getattr_from_kwargs_when_no_json(self):
         """returns value from _kwargs when _json_repo is None"""
-        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem", stars=99)
+        gh = GitHubData(owner="Qiskit", repo="qiskit-banana-compiler", stars=99)
         self.assertEqual(gh._kwargs["stars"], 99)
 
     def test_getattr_missing_raises_attribute_error_no_json(self):
@@ -154,15 +162,15 @@ class TestGitHubDataUpdateOwnerRepo(TestCase):
 
     def test_update_owner_repo_no_change(self):
         """owner and repo unchanged when JSON matches"""
-        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
-        gh._json_repo = {"owner": {"login": "Qiskit"}, "name": "qiskit-ecosystem"}
+        gh = GitHubData(owner="Qiskit", repo="qiskit-banana-compiler")
+        gh._json_repo = {"owner": {"login": "Qiskit"}, "name": "qiskit-banana-compiler"}
         gh.update_owner_repo()
         self.assertEqual(gh.owner, "Qiskit")
-        self.assertEqual(gh.repo, "qiskit-ecosystem")
+        self.assertEqual(gh.repo, "qiskit-banana-compiler")
 
     def test_update_owner_repo_detects_rename(self):
         """owner and repo updated when JSON has different values"""
-        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
+        gh = GitHubData(owner="Qiskit", repo="qiskit-banana-compiler")
         gh._json_repo = {"owner": {"login": "NewOwner"}, "name": "new-repo"}
         gh.update_owner_repo()
         self.assertEqual(gh.owner, "NewOwner")
@@ -174,7 +182,7 @@ class TestGitHubDataUpdateJson(TestCase):
 
     def test_update_json_populates_json_repo(self):
         """after update_json, _json_repo is set"""
-        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
+        gh = GitHubData(owner="Qiskit", repo="qiskit-banana-compiler")
         with patch("ecosystem.github.request_json") as mock_request:
             mock_request.return_value = {"data": {}, "_requested_at_": "2024-01-01"}
             gh._json_package_ids = {}
@@ -183,7 +191,7 @@ class TestGitHubDataUpdateJson(TestCase):
 
     def test_update_json_fetches_dependants_per_package(self):
         """fetches dependants for each package returned"""
-        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
+        gh = GitHubData(owner="Qiskit", repo="qiskit-banana-compiler")
         fake_response = {"data": {}, "_requested_at_": "2024-01-01"}
         with patch("ecosystem.github.request_json") as mock_request:
             mock_request.side_effect = [
@@ -202,14 +210,14 @@ class TestGitHubDataProperties(TestCase):
 
     def test_dependants_refresh_calls_update_json(self):
         """refresh=True triggers update_json()"""
-        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
+        gh = GitHubData(owner="Qiskit", repo="qiskit-banana-compiler")
         with patch.object(GitHubData, "update_json") as mock_update:
             gh.dependants(refresh=True)
             mock_update.assert_called_once()
 
     def test_total_dependent_repositories_sums_correctly(self):
         """sums repositories across all packages in dependants"""
-        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
+        gh = GitHubData(owner="Qiskit", repo="qiskit-banana-compiler")
         gh._json_dependants = {
             "pkg1": {"repositories": 10},
             "pkg2": {"repositories": 5},
@@ -218,7 +226,7 @@ class TestGitHubDataProperties(TestCase):
 
     def test_total_dependent_packages_sums_correctly(self):
         """sums packages across all packages in dependants"""
-        gh = GitHubData(owner="Qiskit", repo="qiskit-ecosystem")
+        gh = GitHubData(owner="Qiskit", repo="qiskit-banana-compiler")
         gh._json_dependants = {
             "pkg1": {"packages": 3},
             "pkg2": {"packages": 7},


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Added unit tests for `ecosystem/github.py` to increase code coverage

Fixes the following Issue : https://github.com/Qiskit/ecosystem/issues/1107


### Details and comments
Added `tests/github/test_github.py` with 25 tests covering:
- `GitHubData.__init__`  : Default values and kwargs storage
- `GitHubData.from_url` : Valid URLs, non-GitHub URLS, tree paths, and invalid URLs
-  `GitHubData.to_dict` : serialization and None value exclusion
- `GitHubData.__getattr__` : type transform and AttributeError cases
- `GitHubData.update_owner_repo` : rename detection
-  `GitHubData.update_json` : verifies JSON fields are populated and dependents are fetched per package
- `GitHubData.dependants` : refresh behaviour
- `GitHubData.total_dependent_repositories` / `total_dependent_packages` : property computations



- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.