### PR TITLE
Rename QiskitIBMRuntimeC.jl

### DIFF
--- a/resources/members/qiskitibmru_bcde78a1.toml
+++ b/resources/members/qiskitibmru_bcde78a1.toml
@@ -1,6 +1,6 @@
-name = "QiskitIBMRuntimeC.jl"
+name = "QiskitIBMRuntime.jl"
 submission_number = 1172
-url = "https://github.com/Qiskit/QiskitIBMRuntimeC.jl"
+url = "https://github.com/Qiskit/QiskitIBMRuntime.jl"
 description = "Execute circuits on an IBM Quantum computer from the Julia programming language"
 labels = []
 interfaces = [ "Julia",]
@@ -12,11 +12,11 @@ maturity = "experimental"
 status = "Qiskit Project"
 
 [github]
-url = "https://github.com/Qiskit/QiskitIBMRuntimeC.jl"
+url = "https://github.com/Qiskit/QiskitIBMRuntime.jl"
 owner = "Qiskit"
-repo = "QiskitIBMRuntimeC.jl"
+repo = "QiskitIBMRuntime.jl"
 stars = 4
-homepage = "https://qiskit.github.io/QiskitIBMRuntimeC.jl/"
+homepage = "https://qiskit.github.io/QiskitIBMRuntime.jl/"
 license = "Apache License 2.0"
 total_dependent_repositories = 0
 total_dependent_packages = 0


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The QiskitIBMRuntimeC.jl package is being renamed to QiskitIBMRuntime.jl.  


### Details and comments

See https://github.com/Qiskit/QiskitIBMRuntime.jl/issues/18 for details.