### PR TITLE
Add missing [badge] block to nu_zz_map_iqm

### DIFF
--- a/resources/members/nuzzmapi_b1f58e67.toml
+++ b/resources/members/nuzzmapi_b1f58e67.toml
@@ -20,3 +20,7 @@ license = "Apache-2.0"
 description = "Residual ZZ mapping for IQM quantum processors, with a built-in negative control"
 last_commit = 2026-07-21
 last_activity = 2026-07-21
+
+[badge]
+url = "https://qisk.it/e-b1f58e67"
+style = "flat"


### PR DESCRIPTION
The member file for nu_zz_map_iqm is missing the [badge] block:

resources/members/nuzzmapi_b1f58e67.toml

As far as I can tell this is the only file in resources/members/
without one. The values follow the same pattern as other members,
using the first 8 characters of the uuid
(b1f58e67-ab64-4d3c-96dd-0fc6fbba854b).

Happy to adjust if the block is meant to be generated automatically.