### PR TITLE
tox -e formatting

### DIFF
--- a/ecosystem/dao.py
+++ b/ecosystem/dao.py
@@ -24,9 +24,27 @@ File structure:
 from pathlib import Path
 import shutil
 import toml
+from toml import TomlEncoder as TomlEncoderUpstream
 
 from ecosystem.error_handling import logger, EcosystemError
 from ecosystem.member import Member
+
+
+class TomlEncoder(TomlEncoderUpstream):
+    def dump_list(self, v):
+        """Override to dump empty lists without trailing comma"""
+        oneline = f"[{', '.join( str(self.dump_value(u)) for u in v )}]"
+        multiline = (
+            f"[\n{'\n'.join( '  ' + str(self.dump_value(u)) + ',' for u in v )}\n]"
+        )
+        if len(oneline) < 60:
+            return oneline
+        if len(oneline) > 65:
+            max_element = max(len(str(self.dump_value(u))) for u in v if u is not None)
+            if max_element <= 10:
+                return oneline
+            return multiline
+        return oneline
 
 
 class TomlStorage:
@@ -90,7 +108,7 @@ class TomlStorage:
         for submission in data.values():
             submission_dict = submission.to_dict()
             with open(self._name_id_to_path(submission.name_id), "w") as file:
-                toml.dump(submission_dict, file)
+                toml.dump(submission_dict, file, encoder=TomlEncoder(preserve=True))
 
     def __enter__(self) -> dict:
         if self._data is None:

--- a/ecosystem/dao.py
+++ b/ecosystem/dao.py
@@ -31,6 +31,14 @@ from ecosystem.member import Member
 
 
 class TomlEncoder(TomlEncoderUpstream):
+    """TOML encoder that keeps short lists on a single line.
+
+    Upstream's encoder always dumps lists multiline, which makes the diffs of
+    the member TOML files noisy. This subclass renders lists inline when they
+    are short enough to stay readable, and falls back to one element per line
+    otherwise.
+    """
+
     def dump_list(self, v):
         """Override to dump empty lists without trailing comma"""
         oneline = f"[{', '.join( str(self.dump_value(u)) for u in v )}]"
@@ -48,9 +56,7 @@ class TomlEncoder(TomlEncoderUpstream):
 
 
 class TomlStorage:
-    """
-    Read / write TOML files from a dict where keys are repo URLs, and values
-    are Submission objects.
+    """Read / write TOML files from a dict where keys are repo URLs, and values are Member objects.
 
     Can use as a context manager like so:
 

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,15 @@ allowlist_externals =
 envdir = .tox/lint
 commands = black {posargs} ecosystem tests --check
 
+[testenv:formatting]
+allowlist_externals =
+  black
+  taplo
+envdir = .tox/lint
+commands =
+  black {posargs} ecosystem tests
+  taplo fmt resources/*.toml resources/members/*.toml
+
 [testenv:website]
 allowlist_externals =
   bash


### PR DESCRIPTION
and more aware dumper, so some formatting is preserved at dump-time
