### PR TITLE
Update QDSV Bridge metadata for 0.6.7

### DIFF
--- a/resources/members/qdsvbridge_e8734f93.toml
+++ b/resources/members/qdsvbridge_e8734f93.toml
@@ -25,8 +25,8 @@ repo = "qdsv-bridge"
 stars = 1
 license = "MIT"
 description = "QDSV Bridge SDK: controlled semantic-to-IR, oracle and circuit-blueprint compilation for supported quantum problem families."
-last_commit = 2026-08-29
-last_activity = 2026-08-29
+last_commit = 2026-09-02
+last_activity = 2026-09-02
 
 [badge]
 url = "https://qisk.it/e-e8734f93"
@@ -34,8 +34,8 @@ style = "flat"
 
 [pypi.qdsv-bridge]
 package_name = "qdsv-bridge"
-version = "0.6.6"
-last_release_date = 2026-08-22
+version = "0.6.7"
+last_release_date = 2026-09-02
 license = "MIT"
 description = "Public Preview conformance-tested semantic-to-quantum SDK for QDSV logical artifacts."
 url = "https://pypi.org/project/qdsv-bridge/"


### PR DESCRIPTION
## Summary
- Update the QDSV Bridge PyPI metadata to 0.6.7.
- Refresh source activity dates to 2026-09-02.
- Preserve the current Qiskit Ecosystem maturity field without change.

## Validation
- PyPI release: qdsv-bridge 0.6.7
- Source release: qdsvquantum-afk/qdsv-bridge at 2c958827be1787dd42d14e86a2ef90af87491af8

- [x] I have updated the metadata accordingly.
- [x] I have read the CONTRIBUTING document.